### PR TITLE
Fix for file names that are too long for file system

### DIFF
--- a/evernote_backup/note_exporter_util.py
+++ b/evernote_backup/note_exporter_util.py
@@ -44,6 +44,8 @@ def _get_safe_path(target_dir: str, new_name: str) -> str:
 
     safe_name = _get_non_existant_name(safe_name, target_dir)
 
+    safe_name = _trim_name(safe_name)
+
     return os.path.join(target_dir, safe_name)
 
 
@@ -71,3 +73,26 @@ def _get_non_existant_name(safe_name: str, target_dir: str) -> str:
         i += 1
         safe_name = f"{o_name} ({i}){o_ext}"
     return safe_name
+
+
+def _trim_name(safe_name: str) -> str:
+    """ Trim file name to 255 characters while maintaining extension
+        255 characters is max file name length on linux and macOS
+        Windows has a path limit of 260 characters which includes
+        the entire path (drive letter, path, and file name)
+        This does not trim the path length, just the file name
+
+        Raises: ValueError if the file name is too long and cannot be trimmed
+    """
+    max_file_name_length = 255
+    if len(safe_name) <= max_file_name_length:
+        return safe_name
+
+    drop_chars = len(safe_name) - max_file_name_length
+    file_parts = safe_name.rsplit(".", 1)
+    if len(file_parts) != 2:
+        return f"{file_parts[0][:-drop_chars]}"
+    if len(file_parts[0]) > drop_chars:
+        return f"{file_parts[0][:-drop_chars]}.{file_parts[1]}"
+    else:
+        raise ValueError("File name is too long but cannot be safely trimmed: {safe_name}")  # noqa: E501

--- a/tests/test_note_exporter_util.py
+++ b/tests/test_note_exporter_util.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 from evernote_backup import note_exporter_util
 from evernote_backup.note_exporter_util import (
     SafePath,
@@ -56,6 +58,64 @@ def test_get_safe_path():
     result = _get_safe_path(*test_path)
 
     assert expected_result == result
+
+
+def test_safe_path_long_file_name(tmp_path):
+    """Test that SafePath trims a long file name with extension"""
+    test_dir = tmp_path / "test"
+    long_file_name = "X" * 255 + ".ext"
+    expected_file_name = "X" * 251 + ".ext"
+    expected_file = tmp_path / "test" / "test1" / expected_file_name
+
+    safe_path = SafePath(str(test_dir))
+    result_file_path = safe_path.get_file("test1", long_file_name)
+
+    expected_file.touch()
+
+    assert expected_file.is_file()
+    assert result_file_path == str(expected_file)
+
+
+def test_safe_path_long_file_name_no_ext(tmp_path):
+    """Test that SafePath trims a long file name with no extension"""
+    test_dir = tmp_path / "test"
+    long_file_name = "X" * 260
+    expected_file_name = "X" * 255
+    expected_file = tmp_path / "test" / "test1" / expected_file_name
+
+    safe_path = SafePath(str(test_dir))
+    result_file_path = safe_path.get_file("test1", long_file_name)
+
+    expected_file.touch()
+
+    assert expected_file.is_file()
+    assert result_file_path == str(expected_file)
+
+
+def test_safe_path_long_file_name_invalid(tmp_path):
+    """Test that SafePath raises ValueError if path is too long but cannot be trimmed"""
+    test_dir = tmp_path / "test"
+    bad_file_name = "X" + "." + "x" * 255
+
+    safe_path = SafePath(str(test_dir))
+    with pytest.raises(ValueError):
+        safe_path.get_file("test1", bad_file_name)
+
+
+def test_safe_path_no_trim(tmp_path):
+    """Test that the SafePath does not trim the path if the path is not too long"""
+    test_dir = tmp_path / "test"
+    max_file_name = "X" * 251 + ".ext"
+    expected_file_name = max_file_name
+    expected_file = tmp_path / "test" / "test1" / expected_file_name
+
+    safe_path = SafePath(str(test_dir))
+    result_file_path = safe_path.get_file("test1", max_file_name)
+
+    expected_file.touch()
+
+    assert expected_file.is_file()
+    assert result_file_path == str(expected_file)
 
 
 def test_get_non_existant_name_first(mocker):


### PR DESCRIPTION
Fixes #8 by trimming long file names to 255 characters (max on linux and macOS) while preserving extension.  There will still be an issue on Windows which has a max path length (all path components including file name) of 260 characters. This PR does not address long path lengths on Windows.  I added a few tests for various cases.