### PR TITLE
Fix long filenames

### DIFF
--- a/evernote_backup/note_exporter_util.py
+++ b/evernote_backup/note_exporter_util.py
@@ -44,6 +44,8 @@ def _get_safe_path(target_dir: str, new_name: str) -> str:
 
     safe_name = _get_non_existant_name(safe_name, target_dir)
 
+    safe_name = _trim_name(safe_name)
+
     return os.path.join(target_dir, safe_name)
 
 
@@ -71,3 +73,26 @@ def _get_non_existant_name(safe_name: str, target_dir: str) -> str:
         i += 1
         safe_name = f"{o_name} ({i}){o_ext}"
     return safe_name
+
+
+def _trim_name(safe_name: str) -> str:
+    """ Trim file name to 255 characters while maintaining extension
+        255 characters is max file name length on linux and macOS
+        Windows has a path limit of 260 characters which includes
+        the entire path (drive letter, path, and file name)
+        This does not trim the path length, just the file name
+
+        Raises: ValueError if the file name is too long and cannot be trimmed
+    """
+    max_file_name_length = 255
+    if len(safe_name) <= max_file_name_length:
+        return safe_name
+
+    drop_chars = len(safe_name) - max_file_name_length
+    file_parts = safe_name.rsplit(".", 1)
+    if len(file_parts) != 2:
+        return f"{file_parts[0][:-drop_chars]}"
+    if len(file_parts[0]) > drop_chars:
+        return f"{file_parts[0][:-drop_chars]}.{file_parts[1]}"
+    else:
+        raise ValueError("File name is too long but cannot be safely trimmed: {safe_name}")  # noqa: E501

--- a/evernote_backup/note_exporter_util.py
+++ b/evernote_backup/note_exporter_util.py
@@ -2,6 +2,9 @@ import os
 from typing import Dict
 
 
+MAX_FILE_NAME_LEN = 255
+
+
 class SafePath(object):
     """Ensures path for tuples of directory names that may contain bad symbols
 
@@ -44,8 +47,6 @@ def _get_safe_path(target_dir: str, new_name: str) -> str:
 
     safe_name = _get_non_existant_name(safe_name, target_dir)
 
-    safe_name = _trim_name(safe_name)
-
     return os.path.join(target_dir, safe_name)
 
 
@@ -67,28 +68,35 @@ def _replace_bad_characters(string: str) -> str:
 
 
 def _get_non_existant_name(safe_name: str, target_dir: str) -> str:
+    safe_name = _trim_name(safe_name)
     i = 0
     o_name, o_ext = os.path.splitext(safe_name)
     while os.path.exists(os.path.join(target_dir, safe_name)):
         i += 1
         safe_name = f"{o_name} ({i}){o_ext}"
+        if len(safe_name) > MAX_FILE_NAME_LEN:
+            max_len = MAX_FILE_NAME_LEN - len(f" ({i}){o_ext}")
+            o_name = _trim_name(o_name, max_len)
+            safe_name = f"{o_name} ({i}){o_ext}"
+
     return safe_name
 
 
-def _trim_name(safe_name: str) -> str:
+def _trim_name(safe_name: str, max_len=MAX_FILE_NAME_LEN) -> str:
     """ Trim file name to 255 characters while maintaining extension
         255 characters is max file name length on linux and macOS
         Windows has a path limit of 260 characters which includes
         the entire path (drive letter, path, and file name)
         This does not trim the path length, just the file name
 
+        max_len: if provided, trims to this length otherwise MAX_FILE_NAME_LEN
+
         Raises: ValueError if the file name is too long and cannot be trimmed
     """
-    max_file_name_length = 255
-    if len(safe_name) <= max_file_name_length:
+    if len(safe_name) <= max_len:
         return safe_name
 
-    drop_chars = len(safe_name) - max_file_name_length
+    drop_chars = len(safe_name) - max_len
     file_parts = safe_name.rsplit(".", 1)
     if len(file_parts) != 2:
         return f"{file_parts[0][:-drop_chars]}"

--- a/tests/test_note_exporter_util.py
+++ b/tests/test_note_exporter_util.py
@@ -140,6 +140,26 @@ def test_get_non_existant_name(mocker):
     assert expected_filename == result_filename
 
 
+def test_get_non_existant_name_trim(mocker):
+    """Test _get_non_existant_name() trims the file name if it is too long"""
+    initial_name = "X" * 255 + ".ext"
+    expected_filename = "X" * 251 + ".ext"
+    result_filename = _get_non_existant_name(initial_name, "fake_dir")
+
+    assert expected_filename == result_filename
+
+
+def test_get_non_existant_name_trim_bad_name(mocker):
+    """Test _get_non_existant_name() trims the file name if it is too long after incrementing"""
+    mock_file_check = mocker.patch("evernote_backup.note_exporter_util.os.path.exists")
+    mock_file_check.side_effect = [True, True, False]
+    initial_name = "X" * 251 + ".ext"
+    expected_filename = "X" * 247 + " (2).ext"
+    result_filename = _get_non_existant_name(initial_name, "fake_dir")
+
+    assert expected_filename == result_filename
+
+
 def test_replace_bad_characters():
     initial_name = r'test<>:"/\|?*'
     expected_filename = r"test_________"

--- a/tests/test_note_exporter_util.py
+++ b/tests/test_note_exporter_util.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 from evernote_backup import note_exporter_util
 from evernote_backup.note_exporter_util import (
     SafePath,
@@ -56,6 +58,64 @@ def test_get_safe_path():
     result = _get_safe_path(*test_path)
 
     assert expected_result == result
+
+
+def test_safe_path_long_file_name(tmp_path):
+    """Test that SafePath trims a long file name with extension"""
+    test_dir = tmp_path / "test"
+    long_file_name = "X" * 255 + ".ext"
+    expected_file_name = "X" * 251 + ".ext"
+    expected_file = tmp_path / "test" / "test1" / expected_file_name
+
+    safe_path = SafePath(str(test_dir))
+    result_file_path = safe_path.get_file("test1", long_file_name)
+
+    expected_file.touch()
+
+    assert expected_file.is_file()
+    assert result_file_path == str(expected_file)
+
+
+def test_safe_path_long_file_name_no_ext(tmp_path):
+    """Test that SafePath trims a long file name with no extension"""
+    test_dir = tmp_path / "test"
+    long_file_name = "X" * 260
+    expected_file_name = "X" * 255
+    expected_file = tmp_path / "test" / "test1" / expected_file_name
+
+    safe_path = SafePath(str(test_dir))
+    result_file_path = safe_path.get_file("test1", long_file_name)
+
+    expected_file.touch()
+
+    assert expected_file.is_file()
+    assert result_file_path == str(expected_file)
+
+
+def test_safe_path_long_file_name_invalid(tmp_path):
+    """Test that SafePath raises ValueError if path is too long but cannot be trimmed"""
+    test_dir = tmp_path / "test"
+    bad_file_name = "X" + "." + "x" * 255
+
+    safe_path = SafePath(str(test_dir))
+    with pytest.raises(ValueError):
+        safe_path.get_file("test1", bad_file_name)
+
+
+def test_safe_path_no_trim(tmp_path):
+    """Test that the SafePath does not trim the path if the path is not too long"""
+    test_dir = tmp_path / "test"
+    max_file_name = "X" * 251 + ".ext"
+    expected_file_name = max_file_name
+    expected_file = tmp_path / "test" / "test1" / expected_file_name
+
+    safe_path = SafePath(str(test_dir))
+    result_file_path = safe_path.get_file("test1", max_file_name)
+
+    expected_file.touch()
+
+    assert expected_file.is_file()
+    assert result_file_path == str(expected_file)
 
 
 def test_get_non_existant_name_first(mocker):


### PR DESCRIPTION
Improved fix for #8 (file name too long).  This PR moves the trim code to `_get_non_existant_name` so the trimming happens during the increment loop.  

So, if a file name is too long in the form: `REALLY_LONG_NAME.ext`

and is too long by 4 characters, it'll be trimmed to: `REALLY_LONG_.ext` (dropping the 4 characters in `NAME`).

If `REALL_LONG_.ext` exists, it'll be incremented to: `REALLY_L (1).ext` (dropping characters so that the entire name fits within the max file name length.

I think this is the best that can be done to preserve the ability to generate safe names but also trim names that are too long.  An alternate approach would be to catch the OSError and warn the user the note name is too long and cannot be exported then continue on with other notes.  I think most users would prefer the note to be exported with a modified name though and this is likely an edge case affecting very few notes.  (In my library, I had 2 notes out of 6,422 that had names which were too long.)

All tests pass and flake8 is clean for the changes.