### PR TITLE
Add md5 hash to resource, to be used for fix_attachment_reference

### DIFF
--- a/evernote_backup/note_formatter.py
+++ b/evernote_backup/note_formatter.py
@@ -2,6 +2,8 @@
 
 import re
 import uuid
+import hashlib
+import binascii
 from typing import Optional
 
 import xmltodict
@@ -66,9 +68,14 @@ class NoteFormatter(object):
         return str(note_template)
 
     def _fmt_resource(self, resource: Resource) -> dict:
+        # Create MD5 hash
+        md5 = hashlib.md5()
+        md5.update(resource.data.body)
+        md5_hash = binascii.hexlify(md5.digest()).decode()
         return {
             "data": {
                 "@encoding": "base64",
+                "@hash": md5_hash,
                 "#text": self._fmt_raw(fmt_binary(resource.data.body)),
             },
             "mime": resource.mime,


### PR DESCRIPTION
copy from https://github.com/eirikora/enex2html/blob/main/enex2html.py#L323

fixes https://github.com/vzhd1701/evernote-backup/discussions/53