### PR TITLE
Improve rate limit logging in cli.py

### DIFF
--- a/evernote_backup/cli.py
+++ b/evernote_backup/cli.py
@@ -18,7 +18,7 @@ from evernote_backup.cli_app_click_util import (
     group_options,
 )
 from evernote_backup.cli_app_util import ProgramTerminatedError
-from evernote_backup.log_util import get_time_txt, init_logging
+from evernote_backup.log_util import get_time_txt, init_logging, get_time_from_now_txt
 from evernote_backup.version import __version__
 
 opt_user = click.option(
@@ -129,10 +129,11 @@ def handle_errors(f: Callable) -> Callable:
             )
         except EDAMSystemException as e:
             if e.errorCode == EDAMErrorCode.RATE_LIMIT_REACHED:
-                import datetime
-                current_time = datetime.datetime.now()
-                restart_time = current_time + datetime.timedelta(seconds=e.rateLimitDuration)
-                logger.critical(f"Rate limit reached. Restart program at {restart_time.strftime('%Y-%m-%d %H:%M:%S')}")
+                time_at = get_time_from_now_txt(e.rateLimitDuration)
+                time_left = get_time_txt(e.rateLimitDuration)
+                logger.critical(
+                    f"Rate limit reached. Restart program at {time_at} (in {time_left})."
+                )
             else:
                 logger.exception("Evernote server error")
         except TApplicationException as e:

--- a/evernote_backup/cli.py
+++ b/evernote_backup/cli.py
@@ -129,8 +129,10 @@ def handle_errors(f: Callable) -> Callable:
             )
         except EDAMSystemException as e:
             if e.errorCode == EDAMErrorCode.RATE_LIMIT_REACHED:
-                time_left = get_time_txt(e.rateLimitDuration)
-                logger.critical(f"Rate limit reached. Restart program in {time_left}.")
+                import datetime
+                current_time = datetime.datetime.now()
+                restart_time = current_time + datetime.timedelta(seconds=e.rateLimitDuration)
+                logger.critical(f"Rate limit reached. Restart program at {restart_time.strftime('%Y-%m-%d %H:%M:%S')}")
             else:
                 logger.exception("Evernote server error")
         except TApplicationException as e:

--- a/evernote_backup/log_util.py
+++ b/evernote_backup/log_util.py
@@ -2,6 +2,7 @@ import logging
 import logging.config
 import sys
 import time
+import datetime
 from pathlib import Path
 from typing import Any, Optional
 
@@ -106,3 +107,10 @@ def get_time_txt(seconds: int) -> str:
         return time.strftime("%M:%S", time.gmtime(seconds))
 
     return time.strftime("0:%S", time.gmtime(seconds))
+
+
+def get_time_from_now_txt(seconds: int) -> str:
+    current_time = datetime.datetime.now(datetime.UTC).astimezone()
+    restart_time = current_time + datetime.timedelta(seconds=seconds)
+
+    return restart_time.strftime("%Y-%m-%d %H:%M:%S")

--- a/tests/test_op_sync.py
+++ b/tests/test_op_sync.py
@@ -742,7 +742,8 @@ def test_sync_edam_rate_limit_exception_while_download(
     result = cli_invoker("sync", "--database", "fake_db")
 
     assert result.exit_code == 1
-    assert "Rate limit reached. Restart program in 0:10" in result.output
+    assert "Rate limit reached. Restart program at" in result.output
+    assert "(in 0:10)" in result.output
 
 
 @pytest.mark.usefixtures("fake_init_db")


### PR DESCRIPTION
Update rate limit handling to log 'restart time' instead of 'duration' only, adding better context.

If a user does not see the printed message just after printed, it's better to see "Restart program at 20:15" instead of "in 30 min" but the user may see it after an hour and wonder when was the message printed.