### PR TITLE
fix: surface friendly error and add --from-desktop-session to recover token from local Evernote desktop client

### DIFF
--- a/evernote_backup/cli.py
+++ b/evernote_backup/cli.py
@@ -16,6 +16,8 @@ from evernote_backup.cli_app_click_util import (
     FILE_ONLY,
     NaturalOrderGroup,
     group_options,
+    DescribedChoice,
+    DescribedChoiceCommand,
 )
 from evernote_backup.cli_app_util import ProgramTerminatedError
 from evernote_backup.log_util import get_time_txt, init_logging, get_time_from_now_txt
@@ -37,23 +39,57 @@ opt_oauth_port = click.option(
     "--oauth-port",
     default=config_defaults.OAUTH_LOCAL_PORT,
     show_default=True,
-    help="OAuth local server port. (Advanced option, works only with --oauth-mcp, ignored for Yinxiang.)",
+    help=(
+        "OAuth local server port. (Advanced option, works only with"
+        " --oauth-method mcp, ignored for Yinxiang.)"
+    ),
 )
 
 opt_oauth_host = click.option(
     "--oauth-host",
     default=config_defaults.OAUTH_HOST,
     show_default=True,
-    help="OAuth local server host. (Advanced option, works only with --oauth-mcp, ignored for Yinxiang.)",
+    help=(
+        "OAuth local server host. (Advanced option, works only with"
+        " --oauth-method mcp, ignored for Yinxiang.)"
+    ),
 )
 
-opt_oauth_mcp = click.option(
-    "--oauth-mcp",
-    is_flag=True,
+
+opt_oauth_method = click.option(
+    "--oauth-method",
+    type=click.Choice(["desktop", "import", "mcp"], case_sensitive=False),
+    default="desktop",
+    show_default=True,
+    cls=DescribedChoice,
+    choice_help={
+        "desktop": "Start new OAuth session presenting as Evernote Desktop Client (default).",
+        "import": (
+            "Import existing OAuth session from a logged-in Evernote Desktop Client."
+            " (Works only on Windows and macOS, recommended for free plan)"
+        ),
+        "mcp": (
+            "Start new OAuth session using MCP interface API."
+            " (Advanced option. Requires Evernote plan that allows MCP.)"
+        ),
+    },
+    help="OAuth method to use. Ignored for Yinxiang.",
+)
+
+opt_oauth_en_user = click.option(
+    "--oauth-en-user",
     help=(
-        "Use MCP OAuth with a local callback server."
-        " (Advanced option, ignored for Yinxiang."
-        " Requires an Evernote subscription that allows MCP.)"
+        "Evernote user ID to import the refresh token from when multiple"
+        " Desktop Client sessions exist. (Works only with --oauth-method import.)"
+    ),
+)
+
+opt_oauth_en_config_dir = click.option(
+    "--oauth-en-config-dir",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+    help=(
+        "Path to the Evernote Desktop Client config directory."
+        " (Advanced option, works only with --oauth-method import.)"
     ),
 )
 
@@ -62,7 +98,7 @@ opt_token = click.option(
     "-t",
     help=(
         "Manually provide authentication token to use with Evernote API."
-        " (Advanced option, ignores '--user' and '--password' when used.)"
+        " (Advanced option, ignores '--user', '--password' and '--oauth-method' when used.)"
     ),
 )
 
@@ -189,14 +225,16 @@ def cli(quiet: bool, verbose: bool, log: Path) -> None:
     init_logging(log_level, log)
 
 
-@cli.command()
+@cli.command(cls=DescribedChoiceCommand)
 @opt_database
 @group_options(
     opt_user,
     opt_password,
+    opt_oauth_method,
     opt_oauth_port,
     opt_oauth_host,
-    opt_oauth_mcp,
+    opt_oauth_en_user,
+    opt_oauth_en_config_dir,
     opt_token,
 )
 @click.option(
@@ -213,9 +251,11 @@ def init_db(
     database: Path,
     user: Optional[str],
     password: Optional[str],
+    oauth_method: str,
     oauth_port: int,
     oauth_host: str,
-    oauth_mcp: bool,
+    oauth_en_user: Optional[str],
+    oauth_en_config_dir: Optional[Path],
     token: Optional[str],
     force: bool,
     backend: str,
@@ -237,7 +277,9 @@ def init_db(
         network_retry_count=network_retry_count,
         use_system_ssl_ca=use_system_ssl_ca,
         custom_api_data=api_data,
-        oauth_mcp=oauth_mcp,
+        oauth_method=oauth_method,
+        oauth_en_user=oauth_en_user,
+        oauth_en_config_dir=oauth_en_config_dir,
     )
 
 
@@ -389,14 +431,16 @@ def export(
     )
 
 
-@cli.command()
+@cli.command(cls=DescribedChoiceCommand)
 @opt_database
 @group_options(
     opt_user,
     opt_password,
+    opt_oauth_method,
     opt_oauth_port,
     opt_oauth_host,
-    opt_oauth_mcp,
+    opt_oauth_en_user,
+    opt_oauth_en_config_dir,
     opt_token,
 )
 @opt_network_retry_count
@@ -407,9 +451,11 @@ def reauth(
     database: Path,
     user: Optional[str],
     password: Optional[str],
+    oauth_method: str,
     oauth_port: int,
     oauth_host: str,
-    oauth_mcp: bool,
+    oauth_en_user: Optional[str],
+    oauth_en_config_dir: Optional[Path],
     token: Optional[str],
     network_retry_count: int,
     use_system_ssl_ca: bool,
@@ -427,7 +473,9 @@ def reauth(
         network_retry_count=network_retry_count,
         use_system_ssl_ca=use_system_ssl_ca,
         custom_api_data=api_data,
-        oauth_mcp=oauth_mcp,
+        oauth_method=oauth_method,
+        oauth_en_user=oauth_en_user,
+        oauth_en_config_dir=oauth_en_config_dir,
     )
 
 

--- a/evernote_backup/cli_app.py
+++ b/evernote_backup/cli_app.py
@@ -43,7 +43,9 @@ def init_db(
     network_retry_count: int,
     use_system_ssl_ca: bool,
     custom_api_data: Optional[str],
-    oauth_mcp: bool = False,
+    oauth_method: str = "desktop",
+    oauth_en_user: Optional[str] = None,
+    oauth_en_config_dir: Optional[Path] = None,
 ) -> None:
     if not force:
         raise_on_existing_database(database)
@@ -58,7 +60,9 @@ def init_db(
             network_retry_count=network_retry_count,
             use_system_ssl_ca=use_system_ssl_ca,
             custom_api_data=custom_api_data,
-            oauth_mcp=oauth_mcp,
+            oauth_method=oauth_method,
+            oauth_en_user=oauth_en_user,
+            oauth_en_config_dir=oauth_en_config_dir,
         )
 
     auth_resolved = resolve_auth_token(auth_token)
@@ -96,7 +100,9 @@ def reauth(
     network_retry_count: int,
     use_system_ssl_ca: bool,
     custom_api_data: Optional[str],
-    oauth_mcp: bool = False,
+    oauth_method: str = "desktop",
+    oauth_en_user: Optional[str] = None,
+    oauth_en_config_dir: Optional[Path] = None,
 ) -> None:
     storage = get_storage(database)
 
@@ -114,7 +120,9 @@ def reauth(
             network_retry_count=network_retry_count,
             use_system_ssl_ca=use_system_ssl_ca,
             custom_api_data=custom_api_data,
-            oauth_mcp=oauth_mcp,
+            oauth_method=oauth_method,
+            oauth_en_user=oauth_en_user,
+            oauth_en_config_dir=oauth_en_config_dir,
         )
 
     auth_resolved = resolve_auth_token(auth_token)

--- a/evernote_backup/cli_app_auth.py
+++ b/evernote_backup/cli_app_auth.py
@@ -1,9 +1,14 @@
 import logging
+from pathlib import Path
 from typing import Optional
 
-from evernote_backup.cli_app_auth_oauth import evernote_login_oauth
+from evernote_backup.cli_app_auth_oauth import (
+    evernote_login_oauth_import,
+    evernote_login_oauth_mcp,
+    evernote_login_oauth_desktop,
+)
 from evernote_backup.cli_app_auth_password import evernote_login_password
-from evernote_backup.cli_app_util import ProgramTerminatedError
+from evernote_backup.cli_app_util import ProgramTerminatedError, is_output_to_terminal
 from evernote_backup.evernote_client import EvernoteClient
 from evernote_backup.evernote_client_sync import EvernoteClientSync
 from evernote_backup.evernote_client_util import EvernoteAuthError
@@ -53,7 +58,9 @@ def get_auth_token(
     network_retry_count: int,
     use_system_ssl_ca: bool,
     custom_api_data: Optional[str],
-    oauth_mcp: bool = False,
+    oauth_method: str = "desktop",
+    oauth_en_user: Optional[str] = None,
+    oauth_en_config_dir: Optional[Path] = None,
 ) -> str:
     logger.info("Logging in to Evernote...")
 
@@ -71,17 +78,24 @@ def get_auth_token(
             custom_api_data=custom_api_data,
         )
 
-    if oauth_mcp:
-        logger.info("Using MCP OAuth authentication...")
-    else:
-        logger.info("Using Desktop OAuth authentication (paste redirect URL)...")
+    if oauth_method == "import":
+        logger.info(
+            "Importing OAuth refresh token from Evernote Desktop Client session..."
+        )
+        return evernote_login_oauth_import(
+            user_id=oauth_en_user,
+            config_dir=oauth_en_config_dir,
+        )
 
-    return evernote_login_oauth(
-        backend=backend,
-        oauth_port=auth_oauth_port,
-        oauth_host=auth_oauth_host,
-        oauth_mcp=oauth_mcp,
-    )
+    if not is_output_to_terminal():
+        raise ProgramTerminatedError("OAuth requires user input!")
+
+    if oauth_method == "mcp":
+        logger.info("Using MCP OAuth authentication...")
+        return evernote_login_oauth_mcp(backend, auth_oauth_port, auth_oauth_host)
+
+    logger.info("Using Desktop OAuth authentication (paste redirect URL)...")
+    return evernote_login_oauth_desktop(backend)
 
 
 def get_ping_client(

--- a/evernote_backup/cli_app_auth_oauth.py
+++ b/evernote_backup/cli_app_auth_oauth.py
@@ -1,11 +1,14 @@
+import logging
+import sys
+from pathlib import Path
 from typing import Optional
 
 import click
 
 from evernote_backup.cli_app_util import (
     ProgramTerminatedError,
-    is_output_to_terminal,
 )
+from evernote_backup.desktop_session import extract_token
 from evernote_backup.errors import OAuthDeclinedError
 from evernote_backup.evernote_client_oauth import (
     EvernoteOAuthCallbackHandler,
@@ -13,34 +16,40 @@ from evernote_backup.evernote_client_oauth import (
     EvernoteOAuthDesktopHandler,
 )
 
-
-def prompt_ota(delivery_hint: str) -> str:
-    if not is_output_to_terminal():
-        raise ProgramTerminatedError("Two-factor authentication requires user input!")
-
-    one_time_hint = ""
-    if delivery_hint:
-        one_time_hint = f" ({delivery_hint})"
-
-    return str(click.prompt(f"Enter one-time code{one_time_hint}"))
+logger = logging.getLogger(__name__)
 
 
-def evernote_login_oauth(
-    backend: str,
-    oauth_port: int,
-    oauth_host: str,
-    oauth_mcp: bool = False,
+def evernote_login_oauth_import(
+    user_id: Optional[str] = None,
+    config_dir: Optional[Path] = None,
 ) -> str:
-    if not is_output_to_terminal():
-        raise ProgramTerminatedError("OAuth requires user input!")
+    if sys.platform != "darwin" and not sys.platform.startswith("win"):
+        raise ProgramTerminatedError(
+            "Importing an OAuth refresh token from the Evernote Desktop Client is only"
+            " supported on Windows and macOS.\n"
+            "You can extract refresh token manually on another system using evertoken app:"
+            " https://github.com/vzhd1701/evertoken"
+        )
 
-    if oauth_mcp:
-        return _evernote_login_oauth_mcp(backend, oauth_port, oauth_host)
+    session = extract_token(user_id=user_id, config_dir=config_dir)
 
-    return _evernote_login_oauth_desktop(backend)
+    if not session.jwt_refresh:
+        raise ProgramTerminatedError(
+            f"Desktop session for user {session.user_id!r} has no OAuth refresh"
+            " token. Log in again in the Evernote Desktop Client and retry."
+        )
+
+    logger.info(
+        f"Imported OAuth refresh token from Desktop Client session"
+        f" (user {session.user_id}"
+        f"{f', {session.username}' if session.username else ''}"
+        f"{f', {session.email}' if session.email else ''})."
+    )
+
+    return session.jwt_refresh
 
 
-def _evernote_login_oauth_mcp(
+def evernote_login_oauth_mcp(
     backend: str,
     oauth_port: int,
     oauth_host: str,
@@ -63,7 +72,7 @@ def _evernote_login_oauth_mcp(
         raise ProgramTerminatedError(f"OAuth error: {e}") from e
 
 
-def _evernote_login_oauth_desktop(backend: str) -> str:
+def evernote_login_oauth_desktop(backend: str) -> str:
     oauth_client = EvernoteOAuthClient(backend=backend)
     oauth_handler = EvernoteOAuthDesktopHandler(oauth_client)
 
@@ -80,6 +89,8 @@ def _evernote_login_oauth_desktop(backend: str) -> str:
         "\n"
         "WARNING: free Evernote accounts allow only one active login session.\n"
         "This may sign you out of the Evernote Desktop app.\n"
+        "To avoid this, re-run with --oauth-method import to reuse the existing\n"
+        "Desktop Client session instead of starting a new login.\n"
     )
     click.launch(oauth_url)
 

--- a/evernote_backup/cli_app_auth_password.py
+++ b/evernote_backup/cli_app_auth_password.py
@@ -3,7 +3,6 @@ from typing import Optional
 import click
 from evernote.edam.userstore.ttypes import AuthenticationResult
 
-from evernote_backup.cli_app_auth_oauth import prompt_ota
 from evernote_backup.cli_app_util import (
     ProgramTerminatedError,
     get_api_data,
@@ -80,9 +79,20 @@ def evernote_login_password(
 def handle_two_factor_auth(
     auth_client: EvernoteClientAuth, token: str, delivery_hint: str
 ) -> AuthenticationResult:
-    ota_code = prompt_ota(delivery_hint)
+    ota_code = _prompt_ota(delivery_hint)
 
     try:
         return auth_client.two_factor_auth(token, ota_code)
     except EvernoteAuthError as e:
         raise ProgramTerminatedError(e)
+
+
+def _prompt_ota(delivery_hint: str) -> str:
+    if not is_output_to_terminal():
+        raise ProgramTerminatedError("Two-factor authentication requires user input!")
+
+    one_time_hint = ""
+    if delivery_hint:
+        one_time_hint = f" ({delivery_hint})"
+
+    return str(click.prompt(f"Enter one-time code{one_time_hint}"))

--- a/evernote_backup/cli_app_click_util.py
+++ b/evernote_backup/cli_app_click_util.py
@@ -23,6 +23,32 @@ class NaturalOrderGroup(click.Group):
         return list(self.commands.keys())
 
 
+class DescribedChoice(click.Option):
+    """A Choice option whose choices get indented, aligned help lines."""
+
+    def __init__(self, *args, choice_help: dict[str, str], **kwargs):
+        self.choice_help = choice_help
+        super().__init__(*args, **kwargs)
+
+
+class DescribedChoiceCommand(click.Command):
+    """Command that inlines DescribedChoice per-choice help under the option."""
+
+    def format_options(self, ctx, formatter):
+        rows = []
+        for param in self.get_params(ctx):
+            record = param.get_help_record(ctx)
+            if record is None:
+                continue
+            rows.append(record)
+            if isinstance(param, DescribedChoice):
+                for choice, text in param.choice_help.items():
+                    rows.append((f"    {choice}", text))
+        if rows:
+            with formatter.section("Options"):
+                formatter.write_dl(rows)
+
+
 def group_options(*options: Callable) -> Callable:
     def wrapper(function: Callable) -> Callable:
         for option in reversed(options):

--- a/evernote_backup/desktop_session.py
+++ b/evernote_backup/desktop_session.py
@@ -67,9 +67,13 @@ def _default_config_dir() -> Path:
         appdata = os.environ.get("APPDATA")
         if appdata:
             return Path(appdata) / "Evernote"
-    elif sys.platform == "darwin":
+        return Path.home() / "Evernote"
+    if sys.platform == "darwin":
         return Path.home() / "Library" / "Application Support" / "Evernote"
-    return Path.home() / "Evernote"
+    raise ProgramTerminatedError(
+        f"Evernote desktop session extraction is only supported on Windows"
+        f" and macOS (this platform is {sys.platform!r})."
+    )
 
 
 def _conduit_subdir(config_dir: Path) -> Path:

--- a/evernote_backup/desktop_session.py
+++ b/evernote_backup/desktop_session.py
@@ -1,0 +1,366 @@
+"""Extract the Evernote auth token from a logged-in Evernote desktop client.
+
+When the legacy Evernote OAuth 1.0a endpoint at www.evernote.com/oauth was
+retired by Bending Spoons (who acquired Evernote in 2023), there is no
+longer a way for ``evernote-backup init-db`` to obtain a fresh ``S=...``
+token on its own. The new Evernote desktop client (Windows / macOS)
+still holds a valid token in the user's local profile - in an encrypted
+blob in the Evernote user config directory.
+
+This module ports the algorithm used by vzhd1701/evertoken (Go) into
+Python so ``evernote-backup`` can recover the token automatically when
+``--from-desktop-session`` is passed.
+
+Algorithm
+---------
+1. Locate the Evernote user config directory (per platform).
+2. Open ``conduit-storage/.../_ConduitMultiUserDB.sql`` to enumerate the
+   logged-in user(s).
+3. For each user, locate ``secure-storage/authtoken_user_<userID>`` (a
+   JSON file with ``{"iv": "<b64>", "encrypted": "<ISO-8859-1 binary>"}``).
+4. Fetch the AES-256 key for that user from the OS secret store
+   (Windows Credential Manager / macOS Keychain / Linux libsecret).
+5. Decrypt with AES-256-CBC, strip PKCS7, base64-decode, parse the JSON
+   user-store blob. Its ``t`` field is the classic ``S=...`` token.
+
+If multiple users are present the caller can pick one by Evernote user
+ID via :func:`extract_token` ``user_id=``; otherwise the first one is
+returned.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+from evernote_backup.cli_app_util import ProgramTerminatedError
+
+# key prefix as stored in the OS secret store (Windows CredMan blob and
+# macOS Keychain password are both prefixed with this same string).
+_KEY_PREFIX = "enote-encr-key"
+
+
+@dataclass
+class DesktopSession:
+    """One logged-in Evernote user recovered from the desktop client."""
+
+    user_id: str
+    username: str
+    email: str
+    s_token: str
+    shard: str
+    host: str
+    jwt_access: Optional[str] = None
+    jwt_refresh: Optional[str] = None
+    client_id: Optional[str] = None
+    storage_path: Optional[Path] = None
+
+
+# ---------------------------------------------------------------------------
+# Platform-specific user-config-directory discovery + secure-storage read
+# ---------------------------------------------------------------------------
+
+
+def _default_config_dir() -> Path:
+    """Best-effort location of the Evernote user config directory."""
+    if sys.platform.startswith("win"):
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            return Path(appdata) / "Evernote"
+    elif sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "Evernote"
+    else:
+        xdg = os.environ.get("XDG_CONFIG_HOME")
+        if xdg:
+            return Path(xdg) / "Evernote"
+        return Path.home() / ".config" / "Evernote"
+    return Path.home() / "Evernote"
+
+
+def _conduit_subdir(config_dir: Path) -> Path:
+    """Path to the conduit-storage host subdirectory."""
+    return config_dir / "conduit-storage" / "https%3A%2F%2Fwww.evernote.com"
+
+
+def _multi_user_db(config_dir: Path) -> Path:
+    return _conduit_subdir(config_dir) / "_ConduitMultiUserDB.sql"
+
+
+def _secure_storage_dir(config_dir: Path) -> Path:
+    return config_dir / "secure-storage"
+
+
+def list_desktop_users(config_dir: Optional[Path] = None) -> List[DesktopSession]:
+    """Enumerate the users currently logged in to the Evernote desktop client.
+
+    Returns one :class:`DesktopSession` per user with ``s_token`` etc. left
+    blank - call :func:`extract_token` (or just read ``s_token`` after
+    picking) to actually decrypt each user's secure-storage blob.
+    """
+    config_dir = config_dir or _default_config_dir()
+    db_path = _multi_user_db(config_dir)
+    if not db_path.exists():
+        raise ProgramTerminatedError(
+            f"Evernote desktop user database not found at {db_path}."
+            " Make sure the Evernote desktop app is installed and at least"
+            " one user is logged in."
+        )
+
+    con = sqlite3.connect(str(db_path))
+    try:
+        cur = con.cursor()
+        cur.execute("SELECT Tkey, TValue FROM MultiUsers")
+        out: List[DesktopSession] = []
+        for tkey, tvalue in cur.fetchall():
+            try:
+                data = json.loads(tvalue)
+            except json.JSONDecodeError:
+                continue
+            user_id = tkey.split(":", 1)[1]
+            out.append(
+                DesktopSession(
+                    user_id=user_id,
+                    username=str(data.get("username", "?")),
+                    email=str(data.get("email", "?")),
+                    s_token="",
+                    shard="",
+                    host="",
+                    storage_path=_secure_storage_dir(config_dir)
+                    / f"authtoken_user_{user_id}",
+                )
+            )
+    finally:
+        con.close()
+    return out
+
+
+# ---------------------------------------------------------------------------
+# OS secret-store reads (per platform)
+# ---------------------------------------------------------------------------
+
+
+def _get_key_windows(target: str) -> bytes:
+    """Read a generic credential from Windows Credential Manager."""
+    try:
+        import win32cred  # type: ignore
+    except ImportError as e:  # pragma: no cover
+        raise ProgramTerminatedError(
+            "Reading the Evernote auth key on Windows requires the"
+            " 'pywin32' package. Install it with:"
+            " `pip install pywin32`."
+        ) from e
+
+    try:
+        cred = win32cred.CredRead(target, win32cred.CRED_TYPE_GENERIC, 0)
+    except Exception as e:  # noqa: BLE001
+        raise ProgramTerminatedError(
+            f"Could not read Windows credential '{target}': {e}."
+            " Is the Evernote desktop client installed and logged in for"
+            " the current user?"
+        ) from e
+
+    blob = cred["CredentialBlob"]
+    if not isinstance(blob, bytes):
+        blob = blob.encode("utf-16-le")
+    if not blob.startswith(_KEY_PREFIX.encode("ascii")):
+        raise ProgramTerminatedError(
+            f"Windows credential '{target}' has unexpected prefix"
+            f" {blob[:len(_KEY_PREFIX)]!r}; cannot decrypt Evernote token."
+        )
+    return base64.b64decode(blob[len(_KEY_PREFIX):])
+
+
+def _get_key_macos(target: str) -> bytes:
+    """Read a generic password item from the macOS Keychain."""
+    if not shutil.which("/usr/bin/security"):
+        raise ProgramTerminatedError(
+            "/usr/bin/security not found; cannot read macOS Keychain."
+        )
+    try:
+        out = subprocess.run(
+            [
+                "/usr/bin/security",
+                "find-generic-password",
+                "-s", target.split("/", 1)[0],
+                "-wa", target,
+            ],
+            check=True,
+            capture_output=True,
+            timeout=10,
+        )
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or b"").decode("utf-8", "replace").strip()
+        raise ProgramTerminatedError(
+            f"Could not read macOS Keychain entry '{target}': {stderr}."
+            " Is the Evernote desktop client installed and logged in for"
+            " the current user?"
+        ) from e
+    data = out.stdout.strip()
+    if data.startswith(_KEY_PREFIX.encode("ascii")):
+        data = data[len(_KEY_PREFIX):]
+    return base64.b64decode(data)
+
+
+def _get_key_linux(target: str) -> bytes:
+    """Read a secret from libsecret via the ``secret-tool`` CLI."""
+    if not shutil.which("secret-tool"):
+        raise ProgramTerminatedError(
+            "The 'secret-tool' CLI is required to read the Evernote"
+            " key from libsecret on Linux. Install it (e.g. via"
+            " libsecret-tools) and make sure a Secret Service provider"
+            " such as GNOME Keyring or KWallet is running for the"
+            " current user."
+        )
+    service = target.split("/", 1)[0]
+    account = target[len(service) + 1 :] if "/" in target else ""
+    try:
+        out = subprocess.run(
+            [
+                "secret-tool",
+                "lookup",
+                "service", service,
+                "account", account,
+            ],
+            check=True,
+            capture_output=True,
+            timeout=10,
+        )
+    except subprocess.CalledProcessError as e:
+        raise ProgramTerminatedError(
+            f"Could not read libsecret entry service={service}"
+            f" account={account}: {e}."
+        ) from e
+    data = out.stdout.strip()
+    if data.startswith(_KEY_PREFIX.encode("ascii")):
+        data = data[len(_KEY_PREFIX):]
+    return base64.b64decode(data)
+
+
+def _get_os_key(target: str) -> bytes:
+    if sys.platform.startswith("win"):
+        return _get_key_windows(target)
+    if sys.platform == "darwin":
+        return _get_key_macos(target)
+    return _get_key_linux(target)
+
+
+# ---------------------------------------------------------------------------
+# AES-256-CBC decrypt of the secure-storage blob
+# ---------------------------------------------------------------------------
+
+
+def _decrypt_secure_blob(blob_path: Path, key: bytes) -> dict:
+    """Decrypt ``authtoken_user_*`` and return the parsed user-store dict."""
+    try:
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+        from cryptography.hazmat.backends import default_backend
+    except ImportError as e:  # pragma: no cover
+        raise ProgramTerminatedError(
+            "Decrypting the Evernote secure-storage blob requires the"
+            " 'cryptography' package. Install it with:"
+            " `pip install cryptography`."
+        ) from e
+
+    if len(key) != 32:
+        raise ProgramTerminatedError(
+            f"Unexpected AES key length {len(key)} (need 32 for AES-256)."
+        )
+
+    blob = json.loads(blob_path.read_text(encoding="utf-8"))
+    iv = base64.b64decode(blob["iv"])
+    # Evernote writes each raw ciphertext byte as one ISO-8859-1 char in
+    # the JSON "encrypted" field.
+    ciphertext = blob["encrypted"].encode("latin-1")
+
+    cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
+    dec = cipher.decryptor()
+    padded = dec.update(ciphertext) + dec.finalize()
+    pad = padded[-1]
+    if not (0 < pad <= 16) or any(b != pad for b in padded[-pad:]):
+        raise ProgramTerminatedError(
+            f"Invalid PKCS7 padding in {blob_path.name}; key may be wrong."
+        )
+    plaintext = padded[: len(padded) - pad]
+
+    # Plaintext is a base64-encoded JSON blob describing the user store.
+    userstore_b64 = plaintext.decode("utf-8")
+    return json.loads(base64.b64decode(userstore_b64))
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def extract_token(
+    user_id: Optional[str] = None,
+    config_dir: Optional[Path] = None,
+) -> DesktopSession:
+    """Pull the ``S=...`` auth token out of the Evernote desktop client.
+
+    Parameters
+    ----------
+    user_id
+        If the desktop client has multiple logged-in users, pick the
+        one with this Evernote user ID. Defaults to the only/first user.
+    config_dir
+        Override the Evernote user config directory (advanced).
+
+    Raises :class:`ProgramTerminatedError` if the desktop client isn't
+    installed, no user is logged in, or the secure storage can't be
+    decrypted.
+    """
+    config_dir = config_dir or _default_config_dir()
+
+    users = list_desktop_users(config_dir)
+    if not users:
+        raise ProgramTerminatedError(
+            "No logged-in Evernote desktop users were found."
+        )
+
+    if user_id is not None:
+        chosen = next((u for u in users if u.user_id == user_id), None)
+        if chosen is None:
+            avail = ", ".join(u.user_id for u in users)
+            raise ProgramTerminatedError(
+                f"Requested desktop user {user_id!r} not found;"
+                f" available: {avail}."
+            )
+    elif len(users) == 1:
+        chosen = users[0]
+    else:
+        # Multiple users - take the first one and warn via logger? The CLI
+        # is expected to enumerate them for the user via --list.
+        chosen = users[0]
+
+    if chosen.storage_path is None or not chosen.storage_path.exists():
+        raise ProgramTerminatedError(
+            f"Secure-storage file for user {chosen.user_id!r} not found at"
+            f" {chosen.storage_path}."
+        )
+
+    key = _get_os_key(f"Evernote/AuthToken:User:{chosen.user_id}")
+    data = _decrypt_secure_blob(chosen.storage_path, key)
+
+    chosen.s_token = str(data.get("t", "") or "")
+    chosen.shard = str(data.get("sh", "") or "")
+    chosen.host = str(data.get("h", "") or "")
+    chosen.jwt_access = data.get("j") or None
+    chosen.jwt_refresh = data.get("nrt") or None
+    chosen.client_id = data.get("nci") or None
+
+    if not chosen.s_token:
+        raise ProgramTerminatedError(
+            f"Decrypted secure storage for user {chosen.user_id!r}"
+            " but found no 't' (token) field. The Evernote desktop client"
+            " may need to log in again."
+        )
+
+    return chosen

--- a/evernote_backup/desktop_session.py
+++ b/evernote_backup/desktop_session.py
@@ -1,15 +1,8 @@
 """Extract the Evernote auth token from a logged-in Evernote desktop client.
 
-When the legacy Evernote OAuth 1.0a endpoint at www.evernote.com/oauth was
-retired by Bending Spoons (who acquired Evernote in 2023), there is no
-longer a way for ``evernote-backup init-db`` to obtain a fresh ``S=...``
-token on its own. The new Evernote desktop client (Windows / macOS)
-still holds a valid token in the user's local profile - in an encrypted
+The Evernote desktop client (Windows / macOS)
+holds a valid token in the user's local profile - in an encrypted
 blob in the Evernote user config directory.
-
-This module ports the algorithm used by vzhd1701/evertoken (Go) into
-Python so ``evernote-backup`` can recover the token automatically when
-``--from-desktop-session`` is passed.
 
 Algorithm
 ---------
@@ -163,7 +156,6 @@ def _get_os_key(user_id: str) -> bytes:
     except ImportError as e:  # pragma: no cover
         raise ProgramTerminatedError(
             "Reading the Evernote auth key requires the 'keyring' package."
-            " Install it with: `pip install keyring`."
         ) from e
 
     service, account = _keyring_service_and_account(user_id)
@@ -224,8 +216,7 @@ def _decrypt_secure_blob(blob_path: Path, key: bytes) -> dict:
     except ImportError as e:  # pragma: no cover
         raise ProgramTerminatedError(
             "Decrypting the Evernote secure-storage blob requires the"
-            " 'pycryptodome' package. Install it with:"
-            " `pip install pycryptodome`."
+            " 'pycryptodome' package."
         ) from e
 
     if len(key) != 32:

--- a/evernote_backup/desktop_session.py
+++ b/evernote_backup/desktop_session.py
@@ -19,7 +19,7 @@ Algorithm
 3. For each user, locate ``secure-storage/authtoken_user_<userID>`` (a
    JSON file with ``{"iv": "<b64>", "encrypted": "<ISO-8859-1 binary>"}``).
 4. Fetch the AES-256 key for that user from the OS secret store
-   (Windows Credential Manager / macOS Keychain / Linux libsecret).
+   (Windows Credential Manager / macOS Keychain).
 5. Decrypt with AES-256-CBC, strip PKCS7, base64-decode, parse the JSON
    user-store blob. Its ``t`` field is the classic ``S=...`` token.
 
@@ -27,14 +27,13 @@ If multiple users are present the caller can pick one by Evernote user
 ID via :func:`extract_token` ``user_id=``; otherwise the first one is
 returned.
 """
+
 from __future__ import annotations
 
 import base64
 import json
 import os
-import shutil
 import sqlite3
-import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -45,6 +44,7 @@ from evernote_backup.cli_app_util import ProgramTerminatedError
 # key prefix as stored in the OS secret store (Windows CredMan blob and
 # macOS Keychain password are both prefixed with this same string).
 _KEY_PREFIX = "enote-encr-key"
+_KEYRING_SERVICE = "Evernote"
 
 
 @dataclass
@@ -76,11 +76,6 @@ def _default_config_dir() -> Path:
             return Path(appdata) / "Evernote"
     elif sys.platform == "darwin":
         return Path.home() / "Library" / "Application Support" / "Evernote"
-    else:
-        xdg = os.environ.get("XDG_CONFIG_HOME")
-        if xdg:
-            return Path(xdg) / "Evernote"
-        return Path.home() / ".config" / "Evernote"
     return Path.home() / "Evernote"
 
 
@@ -142,113 +137,78 @@ def list_desktop_users(config_dir: Optional[Path] = None) -> List[DesktopSession
 
 
 # ---------------------------------------------------------------------------
-# OS secret-store reads (per platform)
+# OS secret-store reads via keyring (Windows CredMan / macOS Keychain)
 # ---------------------------------------------------------------------------
 
 
-def _get_key_windows(target: str) -> bytes:
-    """Read a generic credential from Windows Credential Manager."""
+def _keyring_service_and_account(user_id: str) -> tuple[str, str]:
+    """Return ``(service, account)`` for Evernote's AES key in the OS store.
+
+    Evernote (Electron + keytar) stores the key under account
+    ``AuthToken:User:<id>``. On Windows the Credential Manager target name
+    is ``Evernote/AuthToken:User:<id>`` (keyring service name); on macOS
+    the Keychain service is just ``Evernote``.
+    """
+    account = f"AuthToken:User:{user_id}"
+    if sys.platform.startswith("win"):
+        return f"{_KEYRING_SERVICE}/{account}", account
+    return _KEYRING_SERVICE, account
+
+
+def _get_os_key(user_id: str) -> bytes:
+    """Fetch the AES-256 key for *user_id* from the OS secret store."""
     try:
-        import win32cred  # type: ignore
+        import keyring
+        from keyring.errors import KeyringError, KeyringLocked
     except ImportError as e:  # pragma: no cover
         raise ProgramTerminatedError(
-            "Reading the Evernote auth key on Windows requires the"
-            " 'pywin32' package. Install it with:"
-            " `pip install pywin32`."
+            "Reading the Evernote auth key requires the 'keyring' package."
+            " Install it with: `pip install keyring`."
         ) from e
 
+    service, account = _keyring_service_and_account(user_id)
     try:
-        cred = win32cred.CredRead(target, win32cred.CRED_TYPE_GENERIC, 0)
-    except Exception as e:  # noqa: BLE001
+        secret = keyring.get_password(service, account)
+    except KeyringLocked as e:
         raise ProgramTerminatedError(
-            f"Could not read Windows credential '{target}': {e}."
+            "Could not access the system credential store (it is locked)."
+            " Unlock it when prompted, or re-run with the desktop session"
+            " unlocked."
+        ) from e
+    except KeyringError as e:
+        raise ProgramTerminatedError(
+            f"Could not read credential for user {user_id!r}"
+            f" (service={service!r}): {e}."
             " Is the Evernote desktop client installed and logged in for"
             " the current user?"
         ) from e
 
-    blob = cred["CredentialBlob"]
-    if not isinstance(blob, bytes):
-        blob = blob.encode("utf-16-le")
-    if not blob.startswith(_KEY_PREFIX.encode("ascii")):
+    if not secret:
         raise ProgramTerminatedError(
-            f"Windows credential '{target}' has unexpected prefix"
-            f" {blob[:len(_KEY_PREFIX)]!r}; cannot decrypt Evernote token."
-        )
-    return base64.b64decode(blob[len(_KEY_PREFIX):])
-
-
-def _get_key_macos(target: str) -> bytes:
-    """Read a generic password item from the macOS Keychain."""
-    if not shutil.which("/usr/bin/security"):
-        raise ProgramTerminatedError(
-            "/usr/bin/security not found; cannot read macOS Keychain."
-        )
-    try:
-        out = subprocess.run(
-            [
-                "/usr/bin/security",
-                "find-generic-password",
-                "-s", target.split("/", 1)[0],
-                "-wa", target,
-            ],
-            check=True,
-            capture_output=True,
-            timeout=10,
-        )
-    except subprocess.CalledProcessError as e:
-        stderr = (e.stderr or b"").decode("utf-8", "replace").strip()
-        raise ProgramTerminatedError(
-            f"Could not read macOS Keychain entry '{target}': {stderr}."
+            f"No Evernote encryption key found in the credential store for"
+            f" user {user_id!r} (service={service!r}, account={account!r})."
             " Is the Evernote desktop client installed and logged in for"
             " the current user?"
-        ) from e
-    data = out.stdout.strip()
-    if data.startswith(_KEY_PREFIX.encode("ascii")):
-        data = data[len(_KEY_PREFIX):]
-    return base64.b64decode(data)
-
-
-def _get_key_linux(target: str) -> bytes:
-    """Read a secret from libsecret via the ``secret-tool`` CLI."""
-    if not shutil.which("secret-tool"):
-        raise ProgramTerminatedError(
-            "The 'secret-tool' CLI is required to read the Evernote"
-            " key from libsecret on Linux. Install it (e.g. via"
-            " libsecret-tools) and make sure a Secret Service provider"
-            " such as GNOME Keyring or KWallet is running for the"
-            " current user."
         )
-    service = target.split("/", 1)[0]
-    account = target[len(service) + 1 :] if "/" in target else ""
-    try:
-        out = subprocess.run(
-            [
-                "secret-tool",
-                "lookup",
-                "service", service,
-                "account", account,
-            ],
-            check=True,
-            capture_output=True,
-            timeout=10,
-        )
-    except subprocess.CalledProcessError as e:
-        raise ProgramTerminatedError(
-            f"Could not read libsecret entry service={service}"
-            f" account={account}: {e}."
-        ) from e
-    data = out.stdout.strip()
-    if data.startswith(_KEY_PREFIX.encode("ascii")):
-        data = data[len(_KEY_PREFIX):]
-    return base64.b64decode(data)
 
-
-def _get_os_key(target: str) -> bytes:
+    # Evernote stores the secret as raw ASCII bytes
+    # ("enote-encr-key" + base64(key)). keytar writes that as a UTF-8/ASCII
+    # blob on Windows; keyring's WinVault backend decodes CredentialBlob as
+    # UTF-16 first, which misinterprets the ASCII payload. Re-encoding with
+    # utf-16-le restores the original bytes. On macOS the secret is already
+    # a proper UTF-8 string.
     if sys.platform.startswith("win"):
-        return _get_key_windows(target)
-    if sys.platform == "darwin":
-        return _get_key_macos(target)
-    return _get_key_linux(target)
+        raw = secret.encode("utf-16-le")
+    else:
+        raw = secret.encode("utf-8")
+
+    prefix = _KEY_PREFIX.encode("ascii")
+    if not raw.startswith(prefix):
+        raise ProgramTerminatedError(
+            f"Credential for user {user_id!r} has unexpected prefix"
+            f" {raw[: len(prefix)]!r}; cannot decrypt Evernote token."
+        )
+    return base64.b64decode(raw[len(prefix) :])
 
 
 # ---------------------------------------------------------------------------
@@ -259,13 +219,13 @@ def _get_os_key(target: str) -> bytes:
 def _decrypt_secure_blob(blob_path: Path, key: bytes) -> dict:
     """Decrypt ``authtoken_user_*`` and return the parsed user-store dict."""
     try:
-        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-        from cryptography.hazmat.backends import default_backend
+        from Crypto.Cipher import AES
+        from Crypto.Util.Padding import unpad
     except ImportError as e:  # pragma: no cover
         raise ProgramTerminatedError(
             "Decrypting the Evernote secure-storage blob requires the"
-            " 'cryptography' package. Install it with:"
-            " `pip install cryptography`."
+            " 'pycryptodome' package. Install it with:"
+            " `pip install pycryptodome`."
         ) from e
 
     if len(key) != 32:
@@ -279,15 +239,13 @@ def _decrypt_secure_blob(blob_path: Path, key: bytes) -> dict:
     # the JSON "encrypted" field.
     ciphertext = blob["encrypted"].encode("latin-1")
 
-    cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
-    dec = cipher.decryptor()
-    padded = dec.update(ciphertext) + dec.finalize()
-    pad = padded[-1]
-    if not (0 < pad <= 16) or any(b != pad for b in padded[-pad:]):
+    cipher = AES.new(key, AES.MODE_CBC, iv)
+    try:
+        plaintext = unpad(cipher.decrypt(ciphertext), AES.block_size)
+    except ValueError as e:
         raise ProgramTerminatedError(
             f"Invalid PKCS7 padding in {blob_path.name}; key may be wrong."
-        )
-    plaintext = padded[: len(padded) - pad]
+        ) from e
 
     # Plaintext is a base64-encoded JSON blob describing the user store.
     userstore_b64 = plaintext.decode("utf-8")
@@ -321,17 +279,14 @@ def extract_token(
 
     users = list_desktop_users(config_dir)
     if not users:
-        raise ProgramTerminatedError(
-            "No logged-in Evernote desktop users were found."
-        )
+        raise ProgramTerminatedError("No logged-in Evernote desktop users were found.")
 
     if user_id is not None:
         chosen = next((u for u in users if u.user_id == user_id), None)
         if chosen is None:
             avail = ", ".join(u.user_id for u in users)
             raise ProgramTerminatedError(
-                f"Requested desktop user {user_id!r} not found;"
-                f" available: {avail}."
+                f"Requested desktop user {user_id!r} not found; available: {avail}."
             )
     elif len(users) == 1:
         chosen = users[0]
@@ -346,7 +301,7 @@ def extract_token(
             f" {chosen.storage_path}."
         )
 
-    key = _get_os_key(f"Evernote/AuthToken:User:{chosen.user_id}")
+    key = _get_os_key(chosen.user_id)
     data = _decrypt_secure_blob(chosen.storage_path, key)
 
     chosen.s_token = str(data.get("t", "") or "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,9 @@ dependencies = [
     "thrift==0.21.0",
     "evernote-plus==1.28.1.dev2",
     "requests-sse==0.5.1",
-    "pyjwt>=2.8.0",
+    "pyjwt==2.13.0",
+    "pycryptodome==3.23.0 ; sys_platform == 'darwin' or sys_platform == 'win32'",
+    "keyring==25.7.0 ; sys_platform == 'darwin' or sys_platform == 'win32'",
 ]
 license-files = ["LICENSE"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -578,13 +578,10 @@ def mock_output_to_terminal(mocker, monkeypatch):
     tty_mock.is_tty = True
     tty_mock.side_effect = lambda *a, **kw: tty_mock.is_tty
 
-    mocker.patch(
-        "evernote_backup.cli_app_auth_oauth.is_output_to_terminal", new=tty_mock
-    )
+    mocker.patch("evernote_backup.cli_app_auth.is_output_to_terminal", new=tty_mock)
     mocker.patch(
         "evernote_backup.cli_app_auth_password.is_output_to_terminal", new=tty_mock
     )
-    # mocker.patch("evernote_backup.cli.is_output_to_terminal", new=tty_mock)
     mocker.patch("evernote_backup.cli_app_util.is_output_to_terminal", new=tty_mock)
     mocker.patch("evernote_backup.log_util.is_output_to_terminal", new=tty_mock)
 

--- a/tests/test_cli_app_click_util.py
+++ b/tests/test_cli_app_click_util.py
@@ -1,0 +1,106 @@
+import click
+from click.testing import CliRunner
+
+from evernote_backup.cli_app_click_util import DescribedChoice, DescribedChoiceCommand
+
+
+def _make_described_cmd():
+    @click.command(cls=DescribedChoiceCommand)
+    @click.option(
+        "--mode",
+        type=click.Choice(["alpha", "beta"], case_sensitive=False),
+        default="alpha",
+        show_default=True,
+        cls=DescribedChoice,
+        choice_help={
+            "alpha": "First mode description.",
+            "beta": "Second mode description.",
+        },
+        help="Pick a mode.",
+    )
+    @click.option("--plain", help="A normal option.")
+    def cmd(mode, plain):
+        """Sample command."""
+        click.echo(f"mode={mode};plain={plain}")
+
+    return cmd
+
+
+def test_described_choice_stores_choice_help():
+    opt = DescribedChoice(
+        ["--mode"],
+        type=click.Choice(["a", "b"]),
+        choice_help={"a": "help a", "b": "help b"},
+    )
+
+    assert opt.choice_help == {"a": "help a", "b": "help b"}
+
+
+def test_described_choice_command_help_includes_choice_lines():
+    runner = CliRunner()
+    result = runner.invoke(_make_described_cmd(), ["--help"])
+
+    assert result.exit_code == 0
+    assert "--mode [alpha|beta]" in result.output
+    assert "Pick a mode." in result.output
+    assert "alpha" in result.output
+    assert "First mode description." in result.output
+    assert "beta" in result.output
+    assert "Second mode description." in result.output
+    assert "--plain" in result.output
+    assert "A normal option." in result.output
+
+
+def test_described_choice_command_help_indents_choice_names():
+    runner = CliRunner()
+    result = runner.invoke(_make_described_cmd(), ["--help"])
+
+    # Choice rows are rendered with 4-space indent on the name column.
+    assert "    alpha" in result.output
+    assert "    beta" in result.output
+
+
+def test_described_choice_command_parses_choice_value():
+    runner = CliRunner()
+    result = runner.invoke(_make_described_cmd(), ["--mode", "beta", "--plain", "x"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == "mode=beta;plain=x"
+
+
+def test_described_choice_command_rejects_invalid_choice():
+    runner = CliRunner()
+    result = runner.invoke(_make_described_cmd(), ["--mode", "gamma"])
+
+    assert result.exit_code != 0
+    assert "Invalid value" in result.output
+
+
+def test_described_choice_command_skips_hidden_options():
+    @click.command(cls=DescribedChoiceCommand)
+    @click.option("--visible", help="Shown in help.")
+    @click.option("--secret", hidden=True, help="Hidden option.")
+    def cmd(visible, secret):
+        """pass"""
+
+    runner = CliRunner()
+    result = runner.invoke(cmd, ["--help"])
+
+    assert result.exit_code == 0
+    assert "--visible" in result.output
+    assert "Shown in help." in result.output
+    assert "--secret" not in result.output
+    assert "Hidden option." not in result.output
+
+
+def test_described_choice_command_without_custom_options_still_works():
+    @click.command(cls=DescribedChoiceCommand)
+    def cmd():
+        """No custom options here."""
+
+    runner = CliRunner()
+    result = runner.invoke(cmd, ["--help"])
+
+    assert result.exit_code == 0
+    assert "No custom options here." in result.output
+    assert "--help" in result.output

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -10,7 +10,6 @@ import pytest
 
 from evernote_backup.cli_app_util import ProgramTerminatedError
 from evernote_backup.desktop_session import (
-    DesktopSession,
     _decrypt_secure_blob,
     _default_config_dir,
     _get_os_key,

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -1,5 +1,7 @@
 """Tests for the Evernote-desktop-session token extractor."""
 
+from __future__ import annotations
+
 import base64
 import json
 import sqlite3
@@ -23,86 +25,144 @@ pytestmark = pytest.mark.skipif(
     reason="requires Windows or macOS (pycryptodome-dependent features)",
 )
 
-# ---- helpers ---------------------------------------------------------------
 
-FAKE_USER_ID = "151636"
-FAKE_USERNAME = "beernutz"
-FAKE_EMAIL = "beernutz@gmail.com"
-FAKE_S_TOKEN = (
-    "S=s3:U=25054:E=19f97d7cee2:C=19f9769f1e2:P=1dd:A=en-w32-xauth-new:V=2:H=deadbeef"
-)
-FAKE_SHARD = "s3"
-FAKE_HOST = "www.evernote.com"
-FAKE_JWT = "eyJhbGciOiJIUzI1NiJ9.fake.fake"
-FAKE_AES_KEY = b"\x11" * 32  # 32 bytes of 0x11
-FAKE_IV = b"\x22" * 16
+# ---- Fake desktop-session layout -------------------------------------------
 
 
-def _encrypt_userstore_blob(plaintext_json: bytes) -> tuple[bytes, bytes]:
-    """Encrypt with AES-256-CBC + PKCS7, return (ciphertext, iv)."""
-    from Crypto.Cipher import AES
-    from Crypto.Util.Padding import pad
+class FakeDesktopSession:
+    """Configurable fake of an Evernote desktop user-config directory.
 
-    iv = b"\x33" * 16
-    cipher = AES.new(FAKE_AES_KEY, AES.MODE_CBC, iv)
-    return cipher.encrypt(pad(plaintext_json, AES.block_size)), iv
+    Mutate attributes, then call :meth:`write` to materialize (or refresh)
+    the multi-user DB and encrypted secure-storage blob on disk. Same idea
+    as :class:`TokenBundleMock` in conftest.
+    """
 
+    def __init__(self, tmp_path: Path) -> None:
+        self.config_dir = tmp_path / "Evernote"
 
-def _build_userstore_payload() -> bytes:
-    """Build a base64(JSON) payload matching Evernote's secure-storage layout."""
-    payload = {
-        "t": FAKE_S_TOKEN,
-        "sh": FAKE_SHARD,
-        "h": FAKE_HOST,
-        "j": FAKE_JWT,
-    }
-    return base64.b64encode(json.dumps(payload).encode("utf-8"))
+        self.user_id = "151636"
+        self.username = "beernutz"
+        self.email = "beernutz@gmail.com"
 
+        self.s_token = "S=s3:U=25054:E=19f97d7cee2:C=19f9769f1e2:P=1dd:A=en-w32-xauth-new:V=2:H=deadbeef"
+        self.shard = "s3"
+        self.host = "www.evernote.com"
+        self.jwt_access = "eyJhbGciOiJIUzI1NiJ9.fake.fake"
+        self.jwt_refresh: str | None = None
+        self.client_id: str | None = None
 
-def _write_secure_storage(path: Path) -> None:
-    """Write a realistic secure-storage JSON file at *path*."""
-    plaintext = _build_userstore_payload()
-    ciphertext, iv = _encrypt_userstore_blob(plaintext)
-    blob = {
-        "iv": base64.b64encode(iv).decode("ascii"),
-        # Evernote writes each raw byte as one ISO-8859-1 character in JSON.
-        "encrypted": ciphertext.decode("latin-1"),
-    }
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(blob), encoding="utf-8")
+        self.aes_key = b"\x11" * 32
 
+    # -- derived paths -------------------------------------------------------
 
-def _write_multiuser_db(
-    db_path: Path,
-    user_id: str = FAKE_USER_ID,
-    username: str = FAKE_USERNAME,
-    email: str = FAKE_EMAIL,
-) -> None:
-    """Write a minimal _ConduitMultiUserDB.sql with one user."""
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-    con = sqlite3.connect(str(db_path))
-    con.execute("CREATE TABLE MultiUsers (Tkey TEXT, TValue TEXT)")
-    con.execute(
-        "INSERT INTO MultiUsers VALUES (?, ?)",
-        (f"User:{user_id}", json.dumps({"username": username, "email": email})),
-    )
-    con.commit()
-    con.close()
+    @property
+    def multiuser_db_path(self) -> Path:
+        return (
+            self.config_dir
+            / "conduit-storage"
+            / "https%3A%2F%2Fwww.evernote.com"
+            / "_ConduitMultiUserDB.sql"
+        )
+
+    @property
+    def storage_path(self) -> Path:
+        return self.config_dir / "secure-storage" / f"authtoken_user_{self.user_id}"
+
+    # -- payload / crypto ----------------------------------------------------
+
+    @property
+    def userstore_payload(self) -> dict:
+        """JSON dict Evernote stores (base64-encoded) inside the encrypted blob.
+
+        Set any field to ``None`` to omit it from the payload (e.g. drop
+        ``s_token`` to exercise the missing-token error path).
+        """
+        payload: dict = {}
+        if self.s_token is not None:
+            payload["t"] = self.s_token
+        if self.shard is not None:
+            payload["sh"] = self.shard
+        if self.host is not None:
+            payload["h"] = self.host
+        if self.jwt_access is not None:
+            payload["j"] = self.jwt_access
+        if self.jwt_refresh is not None:
+            payload["nrt"] = self.jwt_refresh
+        if self.client_id is not None:
+            payload["nci"] = self.client_id
+        return payload
+
+    def _encrypt_userstore(self) -> tuple[bytes, bytes]:
+        from Crypto.Cipher import AES
+        from Crypto.Util.Padding import pad
+
+        plaintext = base64.b64encode(json.dumps(self.userstore_payload).encode("utf-8"))
+        iv = b"\x33" * 16
+        cipher = AES.new(self.aes_key, AES.MODE_CBC, iv)
+        return cipher.encrypt(pad(plaintext, AES.block_size)), iv
+
+    @property
+    def keyring_secret(self) -> str:
+        """Value that ``keyring.get_password`` should return for this AES key.
+
+        On Windows Evernote stores the credential as raw ASCII bytes; keyring's
+        WinVault backend decodes CredentialBlob as UTF-16, so get_password
+        returns the misinterpreted string. Re-encoding with utf-16-le restores
+        the original. On macOS the secret is a normal UTF-8 string.
+        """
+        raw = b"enote-encr-key" + base64.b64encode(self.aes_key)
+        if sys.platform.startswith("win"):
+            return raw.decode("utf-16")
+        return raw.decode("utf-8")
+
+    # -- materialize on disk -------------------------------------------------
+
+    def write(self) -> Path:
+        """Write multi-user DB + secure-storage blob; return config dir."""
+        self.multiuser_db_path.parent.mkdir(parents=True, exist_ok=True)
+        con = sqlite3.connect(str(self.multiuser_db_path))
+        try:
+            con.execute("DROP TABLE IF EXISTS MultiUsers")
+            con.execute("CREATE TABLE MultiUsers (Tkey TEXT, TValue TEXT)")
+            con.execute(
+                "INSERT INTO MultiUsers VALUES (?, ?)",
+                (
+                    f"User:{self.user_id}",
+                    json.dumps({"username": self.username, "email": self.email}),
+                ),
+            )
+            con.commit()
+        finally:
+            con.close()
+
+        ciphertext, iv = self._encrypt_userstore()
+        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+        self.storage_path.write_text(
+            json.dumps(
+                {
+                    "iv": base64.b64encode(iv).decode("ascii"),
+                    # Evernote writes each raw byte as one ISO-8859-1 char.
+                    "encrypted": ciphertext.decode("latin-1"),
+                }
+            ),
+            encoding="utf-8",
+        )
+        return self.config_dir
+
+    def patch_keyring(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Point ``keyring.get_password`` at this fake's AES key."""
+        monkeypatch.setattr(
+            "keyring.get_password",
+            lambda service, account: self.keyring_secret,
+        )
 
 
 @pytest.fixture
-def fake_evernote_dir(tmp_path: Path) -> Path:
-    """Build a fake Evernote user-config directory with one logged-in user."""
-    cfg = tmp_path / "Evernote"
-    db = (
-        cfg
-        / "conduit-storage"
-        / "https%3A%2F%2Fwww.evernote.com"
-        / "_ConduitMultiUserDB.sql"
-    )
-    _write_multiuser_db(db)
-    _write_secure_storage(cfg / "secure-storage" / f"authtoken_user_{FAKE_USER_ID}")
-    return cfg
+def fake_desktop_session(tmp_path: Path) -> FakeDesktopSession:
+    """Writable fake Evernote desktop config dir with one logged-in user."""
+    fake = FakeDesktopSession(tmp_path)
+    fake.write()
+    return fake
 
 
 # ---- list_desktop_users -----------------------------------------------------
@@ -113,86 +173,67 @@ def test_list_users_no_db(tmp_path):
         list_desktop_users(tmp_path / "Evernote")
 
 
-def test_list_users_returns_logged_in_user(fake_evernote_dir):
-    users = list_desktop_users(fake_evernote_dir)
+def test_list_users_returns_logged_in_user(fake_desktop_session):
+    users = list_desktop_users(fake_desktop_session.config_dir)
     assert len(users) == 1
     u = users[0]
-    assert u.user_id == FAKE_USER_ID
-    assert u.username == FAKE_USERNAME
-    assert u.email == FAKE_EMAIL
+    assert u.user_id == fake_desktop_session.user_id
+    assert u.username == fake_desktop_session.username
+    assert u.email == fake_desktop_session.email
     # Secure-storage path is populated but token not yet decrypted
     assert u.s_token == ""
-    assert u.storage_path == (
-        fake_evernote_dir / "secure-storage" / f"authtoken_user_{FAKE_USER_ID}"
-    )
+    assert u.storage_path == fake_desktop_session.storage_path
 
 
 # ---- _decrypt_secure_blob ---------------------------------------------------
 
 
-def test_decrypt_secure_blob_roundtrip(fake_evernote_dir):
-    blob_path = fake_evernote_dir / "secure-storage" / f"authtoken_user_{FAKE_USER_ID}"
-    data = _decrypt_secure_blob(blob_path, FAKE_AES_KEY)
-    assert data["t"] == FAKE_S_TOKEN
-    assert data["sh"] == FAKE_SHARD
-    assert data["h"] == FAKE_HOST
-    assert data["j"] == FAKE_JWT
+def test_decrypt_secure_blob_roundtrip(fake_desktop_session):
+    data = _decrypt_secure_blob(
+        fake_desktop_session.storage_path, fake_desktop_session.aes_key
+    )
+    assert data["t"] == fake_desktop_session.s_token
+    assert data["sh"] == fake_desktop_session.shard
+    assert data["h"] == fake_desktop_session.host
+    assert data["j"] == fake_desktop_session.jwt_access
 
 
-def test_decrypt_secure_blob_wrong_key_raises(fake_evernote_dir):
-    blob_path = fake_evernote_dir / "secure-storage" / f"authtoken_user_{FAKE_USER_ID}"
+def test_decrypt_secure_blob_wrong_key_raises(fake_desktop_session):
     with pytest.raises(ProgramTerminatedError, match="PKCS7"):
-        _decrypt_secure_blob(blob_path, b"\x00" * 32)
+        _decrypt_secure_blob(fake_desktop_session.storage_path, b"\x00" * 32)
 
 
-def test_decrypt_secure_blob_wrong_key_length_raises(fake_evernote_dir):
-    blob_path = fake_evernote_dir / "secure-storage" / f"authtoken_user_{FAKE_USER_ID}"
+def test_decrypt_secure_blob_wrong_key_length_raises(fake_desktop_session):
     with pytest.raises(ProgramTerminatedError, match="key length"):
-        _decrypt_secure_blob(blob_path, b"\x00" * 16)
+        _decrypt_secure_blob(fake_desktop_session.storage_path, b"\x00" * 16)
 
 
 # ---- OS key via keyring -----------------------------------------------------
 
 
-def _fake_keyring_secret() -> str:
-    """Build the string keyring returns for the AES key.
-
-    On Windows Evernote stores the credential as raw ASCII bytes; keyring's
-    WinVault backend decodes CredentialBlob as UTF-16, so get_password
-    returns the misinterpreted string. Re-encoding with utf-16-le restores
-    the original. On macOS the secret is a normal UTF-8 string.
-    """
-    raw = b"enote-encr-key" + base64.b64encode(FAKE_AES_KEY)
-    if sys.platform.startswith("win"):
-        return raw.decode("utf-16")
-    return raw.decode("utf-8")
-
-
 def test_keyring_service_and_account_windows(monkeypatch):
     monkeypatch.setattr("sys.platform", "win32")
-    service, account = _keyring_service_and_account(FAKE_USER_ID)
-    assert account == f"AuthToken:User:{FAKE_USER_ID}"
-    assert service == f"Evernote/AuthToken:User:{FAKE_USER_ID}"
+    service, account = _keyring_service_and_account("151636")
+    assert account == "AuthToken:User:151636"
+    assert service == "Evernote/AuthToken:User:151636"
 
 
 def test_keyring_service_and_account_darwin(monkeypatch):
     monkeypatch.setattr("sys.platform", "darwin")
-    service, account = _keyring_service_and_account(FAKE_USER_ID)
-    assert account == f"AuthToken:User:{FAKE_USER_ID}"
+    service, account = _keyring_service_and_account("151636")
+    assert account == "AuthToken:User:151636"
     assert service == "Evernote"
 
 
-def test_get_os_key_roundtrip(monkeypatch):
-    monkeypatch.setattr(
-        "keyring.get_password", lambda service, account: _fake_keyring_secret()
-    )
-    assert _get_os_key(FAKE_USER_ID) == FAKE_AES_KEY
+def test_get_os_key_roundtrip(fake_desktop_session, monkeypatch):
+    fake_desktop_session.patch_keyring(monkeypatch)
+    assert _get_os_key(fake_desktop_session.user_id) == fake_desktop_session.aes_key
 
 
 def test_get_os_key_missing_raises(monkeypatch):
     monkeypatch.setattr("keyring.get_password", lambda service, account: None)
     with pytest.raises(ProgramTerminatedError, match="No Evernote encryption key"):
-        _get_os_key(FAKE_USER_ID)
+        _get_os_key("151636")
 
 
 def test_get_os_key_locked_raises(monkeypatch):
@@ -203,62 +244,72 @@ def test_get_os_key_locked_raises(monkeypatch):
 
     monkeypatch.setattr("keyring.get_password", _raise)
     with pytest.raises(ProgramTerminatedError, match="locked"):
-        _get_os_key(FAKE_USER_ID)
+        _get_os_key("151636")
 
 
 # ---- extract_token (with mocked OS key) -------------------------------------
 
 
-def test_extract_token(fake_evernote_dir, monkeypatch):
+def test_extract_token(fake_desktop_session, monkeypatch):
     """End-to-end extraction with a mocked keyring read."""
-    monkeypatch.setattr(
-        "keyring.get_password", lambda service, account: _fake_keyring_secret()
+    fake_desktop_session.patch_keyring(monkeypatch)
+
+    session = extract_token(
+        user_id=fake_desktop_session.user_id,
+        config_dir=fake_desktop_session.config_dir,
     )
-
-    session = extract_token(user_id=FAKE_USER_ID, config_dir=fake_evernote_dir)
-    assert session.s_token == FAKE_S_TOKEN
-    assert session.shard == FAKE_SHARD
-    assert session.host == FAKE_HOST
-    assert session.jwt_access == FAKE_JWT
-    assert session.user_id == FAKE_USER_ID
-    assert session.username == FAKE_USERNAME
-    assert session.email == FAKE_EMAIL
+    assert session.s_token == fake_desktop_session.s_token
+    assert session.shard == fake_desktop_session.shard
+    assert session.host == fake_desktop_session.host
+    assert session.jwt_access == fake_desktop_session.jwt_access
+    assert session.user_id == fake_desktop_session.user_id
+    assert session.username == fake_desktop_session.username
+    assert session.email == fake_desktop_session.email
 
 
-def test_extract_token_no_token_field_raises(fake_evernote_dir, monkeypatch):
+def test_extract_token_custom_jwt(fake_desktop_session, monkeypatch):
+    """Custom JWT / refresh / client_id flow through the encrypted blob."""
+    fake_desktop_session.jwt_access = "eyJ.custom.access"
+    fake_desktop_session.jwt_refresh = "eyJ.custom.refresh"
+    fake_desktop_session.client_id = "custom-client-id"
+    fake_desktop_session.write()
+    fake_desktop_session.patch_keyring(monkeypatch)
+
+    session = extract_token(
+        user_id=fake_desktop_session.user_id,
+        config_dir=fake_desktop_session.config_dir,
+    )
+    assert session.jwt_access == "eyJ.custom.access"
+    assert session.jwt_refresh == "eyJ.custom.refresh"
+    assert session.client_id == "custom-client-id"
+
+
+def test_extract_token_no_token_field_raises(fake_desktop_session, monkeypatch):
     """If the decrypted blob has no 't' field, surface a clear error."""
-    payload = base64.b64encode(b'{"sh": "s3", "h": "www.evernote.com"}')
-    plaintext = payload
-    ciphertext, iv = _encrypt_userstore_blob(plaintext)
-    blob_path = fake_evernote_dir / "secure-storage" / f"authtoken_user_{FAKE_USER_ID}"
-    blob_path.write_text(
-        json.dumps(
-            {
-                "iv": base64.b64encode(iv).decode("ascii"),
-                "encrypted": ciphertext.decode("latin-1"),
-            }
-        ),
-        encoding="utf-8",
-    )
-
-    monkeypatch.setattr(
-        "keyring.get_password", lambda service, account: _fake_keyring_secret()
-    )
+    fake_desktop_session.s_token = None
+    fake_desktop_session.write()
+    fake_desktop_session.patch_keyring(monkeypatch)
 
     with pytest.raises(ProgramTerminatedError, match="no 't' \\(token\\) field"):
-        extract_token(user_id=FAKE_USER_ID, config_dir=fake_evernote_dir)
+        extract_token(
+            user_id=fake_desktop_session.user_id,
+            config_dir=fake_desktop_session.config_dir,
+        )
 
 
-def test_extract_token_missing_user_raises(fake_evernote_dir):
+def test_extract_token_missing_user_raises(fake_desktop_session):
     with pytest.raises(ProgramTerminatedError, match="not found"):
-        extract_token(user_id="999999", config_dir=fake_evernote_dir)
+        extract_token(user_id="999999", config_dir=fake_desktop_session.config_dir)
 
 
-def test_extract_token_key_missing_raises(fake_evernote_dir, monkeypatch):
+def test_extract_token_key_missing_raises(fake_desktop_session, monkeypatch):
     monkeypatch.setattr("keyring.get_password", lambda service, account: None)
 
     with pytest.raises(ProgramTerminatedError, match="No Evernote encryption key"):
-        extract_token(user_id=FAKE_USER_ID, config_dir=fake_evernote_dir)
+        extract_token(
+            user_id=fake_desktop_session.user_id,
+            config_dir=fake_desktop_session.config_dir,
+        )
 
 
 # ---- _default_config_dir per platform --------------------------------------

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -1,0 +1,235 @@
+"""Tests for the Evernote-desktop-session token extractor."""
+import base64
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.backends import default_backend
+
+from evernote_backup.cli_app_util import ProgramTerminatedError
+from evernote_backup.desktop_session import (
+    DesktopSession,
+    _decrypt_secure_blob,
+    _default_config_dir,
+    extract_token,
+    list_desktop_users,
+)
+
+
+# ---- helpers ---------------------------------------------------------------
+
+FAKE_USER_ID = "151636"
+FAKE_USERNAME = "beernutz"
+FAKE_EMAIL = "beernutz@gmail.com"
+FAKE_S_TOKEN = "S=s3:U=25054:E=19f97d7cee2:C=19f9769f1e2:P=1dd:A=en-w32-xauth-new:V=2:H=deadbeef"
+FAKE_SHARD = "s3"
+FAKE_HOST = "www.evernote.com"
+FAKE_JWT = "eyJhbGciOiJIUzI1NiJ9.fake.fake"
+FAKE_AES_KEY = b"\x11" * 32  # 32 bytes of 0x11
+FAKE_IV = b"\x22" * 16
+
+
+def _encrypt_userstore_blob(plaintext_json: bytes) -> tuple[bytes, bytes]:
+    """Encrypt with AES-256-CBC + PKCS7, return (ciphertext, iv)."""
+    pad = 16 - (len(plaintext_json) % 16)
+    padded = plaintext_json + bytes([pad]) * pad
+    iv = b"\x33" * 16
+    cipher = Cipher(algorithms.AES(FAKE_AES_KEY), modes.CBC(iv), backend=default_backend())
+    enc = cipher.encryptor()
+    return enc.update(padded) + enc.finalize(), iv
+
+
+def _build_userstore_payload() -> bytes:
+    """Build a base64(JSON) payload matching Evernote's secure-storage layout."""
+    payload = {
+        "t": FAKE_S_TOKEN,
+        "sh": FAKE_SHARD,
+        "h": FAKE_HOST,
+        "j": FAKE_JWT,
+    }
+    return base64.b64encode(json.dumps(payload).encode("utf-8"))
+
+
+def _write_secure_storage(path: Path) -> None:
+    """Write a realistic secure-storage JSON file at *path*."""
+    plaintext = _build_userstore_payload()
+    ciphertext, iv = _encrypt_userstore_blob(plaintext)
+    blob = {
+        "iv": base64.b64encode(iv).decode("ascii"),
+        # Evernote writes each raw byte as one ISO-8859-1 character in JSON.
+        "encrypted": ciphertext.decode("latin-1"),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(blob), encoding="utf-8")
+
+
+def _write_multiuser_db(db_path: Path, user_id: str = FAKE_USER_ID,
+                        username: str = FAKE_USERNAME,
+                        email: str = FAKE_EMAIL) -> None:
+    """Write a minimal _ConduitMultiUserDB.sql with one user."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(str(db_path))
+    con.execute("CREATE TABLE MultiUsers (Tkey TEXT, TValue TEXT)")
+    con.execute(
+        "INSERT INTO MultiUsers VALUES (?, ?)",
+        (f"User:{user_id}", json.dumps({"username": username, "email": email})),
+    )
+    con.commit()
+    con.close()
+
+
+@pytest.fixture
+def fake_evernote_dir(tmp_path: Path) -> Path:
+    """Build a fake Evernote user-config directory with one logged-in user."""
+    cfg = tmp_path / "Evernote"
+    db = cfg / "conduit-storage" / "https%3A%2F%2Fwww.evernote.com" / "_ConduitMultiUserDB.sql"
+    _write_multiuser_db(db)
+    _write_secure_storage(cfg / "secure-storage" / f"authtoken_user_{FAKE_USER_ID}")
+    return cfg
+
+
+# ---- list_desktop_users -----------------------------------------------------
+
+
+def test_list_users_no_db(tmp_path):
+    with pytest.raises(ProgramTerminatedError, match="not found"):
+        list_desktop_users(tmp_path / "Evernote")
+
+
+def test_list_users_returns_logged_in_user(fake_evernote_dir):
+    users = list_desktop_users(fake_evernote_dir)
+    assert len(users) == 1
+    u = users[0]
+    assert u.user_id == FAKE_USER_ID
+    assert u.username == FAKE_USERNAME
+    assert u.email == FAKE_EMAIL
+    # Secure-storage path is populated but token not yet decrypted
+    assert u.s_token == ""
+    assert u.storage_path == (
+        fake_evernote_dir / "secure-storage" / f"authtoken_user_{FAKE_USER_ID}"
+    )
+
+
+# ---- _decrypt_secure_blob ---------------------------------------------------
+
+
+def test_decrypt_secure_blob_roundtrip(fake_evernote_dir):
+    blob_path = fake_evernote_dir / "secure-storage" / f"authtoken_user_{FAKE_USER_ID}"
+    data = _decrypt_secure_blob(blob_path, FAKE_AES_KEY)
+    assert data["t"] == FAKE_S_TOKEN
+    assert data["sh"] == FAKE_SHARD
+    assert data["h"] == FAKE_HOST
+    assert data["j"] == FAKE_JWT
+
+
+def test_decrypt_secure_blob_wrong_key_raises(fake_evernote_dir):
+    blob_path = fake_evernote_dir / "secure-storage" / f"authtoken_user_{FAKE_USER_ID}"
+    with pytest.raises(ProgramTerminatedError, match="PKCS7"):
+        _decrypt_secure_blob(blob_path, b"\x00" * 32)
+
+
+def test_decrypt_secure_blob_wrong_key_length_raises(fake_evernote_dir):
+    blob_path = fake_evernote_dir / "secure-storage" / f"authtoken_user_{FAKE_USER_ID}"
+    with pytest.raises(ProgramTerminatedError, match="key length"):
+        _decrypt_secure_blob(blob_path, b"\x00" * 16)
+
+
+# ---- extract_token (with mocked OS key) -------------------------------------
+
+
+def test_extract_token_windows(fake_evernote_dir, monkeypatch):
+    """End-to-end extraction with a mocked Windows Credential Manager read."""
+    fake_cred_blob = b"enote-encr-key" + base64.b64encode(FAKE_AES_KEY)
+
+    fake_cred = MagicMock()
+    fake_cred.__getitem__.side_effect = lambda k: {
+        "TargetName": f"Evernote/AuthToken:User:{FAKE_USER_ID}",
+        "CredentialBlob": fake_cred_blob,
+    }[k]
+
+    fake_win32cred = MagicMock()
+    fake_win32cred.CredRead.return_value = fake_cred
+    fake_win32cred.CRED_TYPE_GENERIC = 1
+
+    monkeypatch.setitem(sys_modules := __import__("sys").modules, "win32cred", fake_win32cred)
+
+    session = extract_token(user_id=FAKE_USER_ID, config_dir=fake_evernote_dir)
+    assert session.s_token == FAKE_S_TOKEN
+    assert session.shard == FAKE_SHARD
+    assert session.host == FAKE_HOST
+    assert session.jwt_access == FAKE_JWT
+    assert session.user_id == FAKE_USER_ID
+    assert session.username == FAKE_USERNAME
+    assert session.email == FAKE_EMAIL
+
+
+def test_extract_token_no_token_field_raises(fake_evernote_dir, monkeypatch):
+    """If the decrypted blob has no 't' field, surface a clear error."""
+    payload = base64.b64encode(b'{"sh": "s3", "h": "www.evernote.com"}')
+    plaintext = payload
+    pad = 16 - (len(plaintext) % 16)
+    padded = plaintext + bytes([pad]) * pad
+    iv = b"\x33" * 16
+    cipher = Cipher(algorithms.AES(FAKE_AES_KEY), modes.CBC(iv), backend=default_backend())
+    enc = cipher.encryptor()
+    ciphertext = enc.update(padded) + enc.finalize()
+    blob_path = fake_evernote_dir / "secure-storage" / f"authtoken_user_{FAKE_USER_ID}"
+    blob_path.write_text(json.dumps({
+        "iv": base64.b64encode(iv).decode("ascii"),
+        "encrypted": ciphertext.decode("latin-1"),
+    }), encoding="utf-8")
+
+    fake_cred = MagicMock()
+    fake_cred.__getitem__.side_effect = lambda k: {
+        "CredentialBlob": b"enote-encr-key" + base64.b64encode(FAKE_AES_KEY),
+    }[k]
+    fake_win32cred = MagicMock()
+    fake_win32cred.CredRead.return_value = fake_cred
+    monkeypatch.setitem(__import__("sys").modules, "win32cred", fake_win32cred)
+
+    with pytest.raises(ProgramTerminatedError, match="no 't' \\(token\\) field"):
+        extract_token(user_id=FAKE_USER_ID, config_dir=fake_evernote_dir)
+
+
+def test_extract_token_missing_user_raises(fake_evernote_dir, monkeypatch):
+    fake_win32cred = MagicMock()
+    monkeypatch.setitem(__import__("sys").modules, "win32cred", fake_win32cred)
+    with pytest.raises(ProgramTerminatedError, match="not found"):
+        extract_token(user_id="999999", config_dir=fake_evernote_dir)
+
+
+def test_extract_token_cred_read_error_raises(fake_evernote_dir, monkeypatch):
+    fake_win32cred = MagicMock()
+    fake_win32cred.CredRead.side_effect = Exception("access denied")
+    fake_win32cred.CRED_TYPE_GENERIC = 1
+    monkeypatch.setitem(__import__("sys").modules, "win32cred", fake_win32cred)
+
+    with pytest.raises(ProgramTerminatedError, match="Could not read Windows credential"):
+        extract_token(user_id=FAKE_USER_ID, config_dir=fake_evernote_dir)
+
+
+# ---- _default_config_dir per platform --------------------------------------
+
+
+def test_default_config_dir_windows(monkeypatch):
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setenv("APPDATA", r"C:\Users\scott\AppData\Roaming")
+    assert _default_config_dir() == Path(r"C:\Users\scott\AppData\Roaming\Evernote")
+
+
+def test_default_config_dir_darwin(monkeypatch):
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.delenv("APPDATA", raising=False)
+    monkeypatch.setattr("pathlib.Path.home",
+                        lambda: Path("/Users/scott"), raising=False)
+    assert _default_config_dir() == Path("/Users/scott/Library/Application Support/Evernote")
+
+
+def test_default_config_dir_linux_xdg(monkeypatch):
+    monkeypatch.setattr("sys.platform", "linux")
+    monkeypatch.delenv("APPDATA", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", "/home/scott/.config")
+    assert _default_config_dir() == Path("/home/scott/.config/Evernote")

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -1,30 +1,37 @@
 """Tests for the Evernote-desktop-session token extractor."""
+
 import base64
 import json
 import sqlite3
+import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-from cryptography.hazmat.backends import default_backend
 
 from evernote_backup.cli_app_util import ProgramTerminatedError
 from evernote_backup.desktop_session import (
     DesktopSession,
     _decrypt_secure_blob,
     _default_config_dir,
+    _get_os_key,
+    _keyring_service_and_account,
     extract_token,
     list_desktop_users,
 )
 
+pytestmark = pytest.mark.skipif(
+    sys.platform not in ("win32", "darwin"),
+    reason="requires Windows or macOS (pycryptodome-dependent features)",
+)
 
 # ---- helpers ---------------------------------------------------------------
 
 FAKE_USER_ID = "151636"
 FAKE_USERNAME = "beernutz"
 FAKE_EMAIL = "beernutz@gmail.com"
-FAKE_S_TOKEN = "S=s3:U=25054:E=19f97d7cee2:C=19f9769f1e2:P=1dd:A=en-w32-xauth-new:V=2:H=deadbeef"
+FAKE_S_TOKEN = (
+    "S=s3:U=25054:E=19f97d7cee2:C=19f9769f1e2:P=1dd:A=en-w32-xauth-new:V=2:H=deadbeef"
+)
 FAKE_SHARD = "s3"
 FAKE_HOST = "www.evernote.com"
 FAKE_JWT = "eyJhbGciOiJIUzI1NiJ9.fake.fake"
@@ -34,12 +41,12 @@ FAKE_IV = b"\x22" * 16
 
 def _encrypt_userstore_blob(plaintext_json: bytes) -> tuple[bytes, bytes]:
     """Encrypt with AES-256-CBC + PKCS7, return (ciphertext, iv)."""
-    pad = 16 - (len(plaintext_json) % 16)
-    padded = plaintext_json + bytes([pad]) * pad
+    from Crypto.Cipher import AES
+    from Crypto.Util.Padding import pad
+
     iv = b"\x33" * 16
-    cipher = Cipher(algorithms.AES(FAKE_AES_KEY), modes.CBC(iv), backend=default_backend())
-    enc = cipher.encryptor()
-    return enc.update(padded) + enc.finalize(), iv
+    cipher = AES.new(FAKE_AES_KEY, AES.MODE_CBC, iv)
+    return cipher.encrypt(pad(plaintext_json, AES.block_size)), iv
 
 
 def _build_userstore_payload() -> bytes:
@@ -66,9 +73,12 @@ def _write_secure_storage(path: Path) -> None:
     path.write_text(json.dumps(blob), encoding="utf-8")
 
 
-def _write_multiuser_db(db_path: Path, user_id: str = FAKE_USER_ID,
-                        username: str = FAKE_USERNAME,
-                        email: str = FAKE_EMAIL) -> None:
+def _write_multiuser_db(
+    db_path: Path,
+    user_id: str = FAKE_USER_ID,
+    username: str = FAKE_USERNAME,
+    email: str = FAKE_EMAIL,
+) -> None:
     """Write a minimal _ConduitMultiUserDB.sql with one user."""
     db_path.parent.mkdir(parents=True, exist_ok=True)
     con = sqlite3.connect(str(db_path))
@@ -85,7 +95,12 @@ def _write_multiuser_db(db_path: Path, user_id: str = FAKE_USER_ID,
 def fake_evernote_dir(tmp_path: Path) -> Path:
     """Build a fake Evernote user-config directory with one logged-in user."""
     cfg = tmp_path / "Evernote"
-    db = cfg / "conduit-storage" / "https%3A%2F%2Fwww.evernote.com" / "_ConduitMultiUserDB.sql"
+    db = (
+        cfg
+        / "conduit-storage"
+        / "https%3A%2F%2Fwww.evernote.com"
+        / "_ConduitMultiUserDB.sql"
+    )
     _write_multiuser_db(db)
     _write_secure_storage(cfg / "secure-storage" / f"authtoken_user_{FAKE_USER_ID}")
     return cfg
@@ -137,24 +152,69 @@ def test_decrypt_secure_blob_wrong_key_length_raises(fake_evernote_dir):
         _decrypt_secure_blob(blob_path, b"\x00" * 16)
 
 
+# ---- OS key via keyring -----------------------------------------------------
+
+
+def _fake_keyring_secret() -> str:
+    """Build the string keyring returns for the AES key.
+
+    On Windows Evernote stores the credential as raw ASCII bytes; keyring's
+    WinVault backend decodes CredentialBlob as UTF-16, so get_password
+    returns the misinterpreted string. Re-encoding with utf-16-le restores
+    the original. On macOS the secret is a normal UTF-8 string.
+    """
+    raw = b"enote-encr-key" + base64.b64encode(FAKE_AES_KEY)
+    if sys.platform.startswith("win"):
+        return raw.decode("utf-16")
+    return raw.decode("utf-8")
+
+
+def test_keyring_service_and_account_windows(monkeypatch):
+    monkeypatch.setattr("sys.platform", "win32")
+    service, account = _keyring_service_and_account(FAKE_USER_ID)
+    assert account == f"AuthToken:User:{FAKE_USER_ID}"
+    assert service == f"Evernote/AuthToken:User:{FAKE_USER_ID}"
+
+
+def test_keyring_service_and_account_darwin(monkeypatch):
+    monkeypatch.setattr("sys.platform", "darwin")
+    service, account = _keyring_service_and_account(FAKE_USER_ID)
+    assert account == f"AuthToken:User:{FAKE_USER_ID}"
+    assert service == "Evernote"
+
+
+def test_get_os_key_roundtrip(monkeypatch):
+    monkeypatch.setattr(
+        "keyring.get_password", lambda service, account: _fake_keyring_secret()
+    )
+    assert _get_os_key(FAKE_USER_ID) == FAKE_AES_KEY
+
+
+def test_get_os_key_missing_raises(monkeypatch):
+    monkeypatch.setattr("keyring.get_password", lambda service, account: None)
+    with pytest.raises(ProgramTerminatedError, match="No Evernote encryption key"):
+        _get_os_key(FAKE_USER_ID)
+
+
+def test_get_os_key_locked_raises(monkeypatch):
+    from keyring.errors import KeyringLocked
+
+    def _raise(*_a, **_k):
+        raise KeyringLocked("locked")
+
+    monkeypatch.setattr("keyring.get_password", _raise)
+    with pytest.raises(ProgramTerminatedError, match="locked"):
+        _get_os_key(FAKE_USER_ID)
+
+
 # ---- extract_token (with mocked OS key) -------------------------------------
 
 
-def test_extract_token_windows(fake_evernote_dir, monkeypatch):
-    """End-to-end extraction with a mocked Windows Credential Manager read."""
-    fake_cred_blob = b"enote-encr-key" + base64.b64encode(FAKE_AES_KEY)
-
-    fake_cred = MagicMock()
-    fake_cred.__getitem__.side_effect = lambda k: {
-        "TargetName": f"Evernote/AuthToken:User:{FAKE_USER_ID}",
-        "CredentialBlob": fake_cred_blob,
-    }[k]
-
-    fake_win32cred = MagicMock()
-    fake_win32cred.CredRead.return_value = fake_cred
-    fake_win32cred.CRED_TYPE_GENERIC = 1
-
-    monkeypatch.setitem(sys_modules := __import__("sys").modules, "win32cred", fake_win32cred)
+def test_extract_token(fake_evernote_dir, monkeypatch):
+    """End-to-end extraction with a mocked keyring read."""
+    monkeypatch.setattr(
+        "keyring.get_password", lambda service, account: _fake_keyring_secret()
+    )
 
     session = extract_token(user_id=FAKE_USER_ID, config_dir=fake_evernote_dir)
     assert session.s_token == FAKE_S_TOKEN
@@ -170,44 +230,35 @@ def test_extract_token_no_token_field_raises(fake_evernote_dir, monkeypatch):
     """If the decrypted blob has no 't' field, surface a clear error."""
     payload = base64.b64encode(b'{"sh": "s3", "h": "www.evernote.com"}')
     plaintext = payload
-    pad = 16 - (len(plaintext) % 16)
-    padded = plaintext + bytes([pad]) * pad
-    iv = b"\x33" * 16
-    cipher = Cipher(algorithms.AES(FAKE_AES_KEY), modes.CBC(iv), backend=default_backend())
-    enc = cipher.encryptor()
-    ciphertext = enc.update(padded) + enc.finalize()
+    ciphertext, iv = _encrypt_userstore_blob(plaintext)
     blob_path = fake_evernote_dir / "secure-storage" / f"authtoken_user_{FAKE_USER_ID}"
-    blob_path.write_text(json.dumps({
-        "iv": base64.b64encode(iv).decode("ascii"),
-        "encrypted": ciphertext.decode("latin-1"),
-    }), encoding="utf-8")
+    blob_path.write_text(
+        json.dumps(
+            {
+                "iv": base64.b64encode(iv).decode("ascii"),
+                "encrypted": ciphertext.decode("latin-1"),
+            }
+        ),
+        encoding="utf-8",
+    )
 
-    fake_cred = MagicMock()
-    fake_cred.__getitem__.side_effect = lambda k: {
-        "CredentialBlob": b"enote-encr-key" + base64.b64encode(FAKE_AES_KEY),
-    }[k]
-    fake_win32cred = MagicMock()
-    fake_win32cred.CredRead.return_value = fake_cred
-    monkeypatch.setitem(__import__("sys").modules, "win32cred", fake_win32cred)
+    monkeypatch.setattr(
+        "keyring.get_password", lambda service, account: _fake_keyring_secret()
+    )
 
     with pytest.raises(ProgramTerminatedError, match="no 't' \\(token\\) field"):
         extract_token(user_id=FAKE_USER_ID, config_dir=fake_evernote_dir)
 
 
-def test_extract_token_missing_user_raises(fake_evernote_dir, monkeypatch):
-    fake_win32cred = MagicMock()
-    monkeypatch.setitem(__import__("sys").modules, "win32cred", fake_win32cred)
+def test_extract_token_missing_user_raises(fake_evernote_dir):
     with pytest.raises(ProgramTerminatedError, match="not found"):
         extract_token(user_id="999999", config_dir=fake_evernote_dir)
 
 
-def test_extract_token_cred_read_error_raises(fake_evernote_dir, monkeypatch):
-    fake_win32cred = MagicMock()
-    fake_win32cred.CredRead.side_effect = Exception("access denied")
-    fake_win32cred.CRED_TYPE_GENERIC = 1
-    monkeypatch.setitem(__import__("sys").modules, "win32cred", fake_win32cred)
+def test_extract_token_key_missing_raises(fake_evernote_dir, monkeypatch):
+    monkeypatch.setattr("keyring.get_password", lambda service, account: None)
 
-    with pytest.raises(ProgramTerminatedError, match="Could not read Windows credential"):
+    with pytest.raises(ProgramTerminatedError, match="No Evernote encryption key"):
         extract_token(user_id=FAKE_USER_ID, config_dir=fake_evernote_dir)
 
 
@@ -223,13 +274,9 @@ def test_default_config_dir_windows(monkeypatch):
 def test_default_config_dir_darwin(monkeypatch):
     monkeypatch.setattr("sys.platform", "darwin")
     monkeypatch.delenv("APPDATA", raising=False)
-    monkeypatch.setattr("pathlib.Path.home",
-                        lambda: Path("/Users/scott"), raising=False)
-    assert _default_config_dir() == Path("/Users/scott/Library/Application Support/Evernote")
-
-
-def test_default_config_dir_linux_xdg(monkeypatch):
-    monkeypatch.setattr("sys.platform", "linux")
-    monkeypatch.delenv("APPDATA", raising=False)
-    monkeypatch.setenv("XDG_CONFIG_HOME", "/home/scott/.config")
-    assert _default_config_dir() == Path("/home/scott/.config/Evernote")
+    monkeypatch.setattr(
+        "pathlib.Path.home", lambda: Path("/Users/scott"), raising=False
+    )
+    assert _default_config_dir() == Path(
+        "/Users/scott/Library/Application Support/Evernote"
+    )

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -110,44 +110,86 @@ class FakeDesktopSession:
         returns the misinterpreted string. Re-encoding with utf-16-le restores
         the original. On macOS the secret is a normal UTF-8 string.
         """
+        return self.keyring_secret_for_platform(sys.platform)
+
+    def keyring_secret_for_platform(self, platform: str) -> str:
         raw = b"enote-encr-key" + base64.b64encode(self.aes_key)
-        if sys.platform.startswith("win"):
+        if platform.startswith("win"):
             return raw.decode("utf-16")
         return raw.decode("utf-8")
 
     # -- materialize on disk -------------------------------------------------
 
-    def write(self) -> Path:
-        """Write multi-user DB + secure-storage blob; return config dir."""
+    def _ensure_db(self, *, clear: bool) -> sqlite3.Connection:
         self.multiuser_db_path.parent.mkdir(parents=True, exist_ok=True)
         con = sqlite3.connect(str(self.multiuser_db_path))
-        try:
+        if clear:
             con.execute("DROP TABLE IF EXISTS MultiUsers")
             con.execute("CREATE TABLE MultiUsers (Tkey TEXT, TValue TEXT)")
+        return con
+
+    def write(
+        self,
+        *,
+        clear_db: bool = True,
+        write_storage: bool = True,
+        db_row: dict | None = None,
+    ) -> Path:
+        """Write multi-user DB row + secure-storage blob; return config dir.
+
+        Parameters
+        ----------
+        clear_db
+            When True (default), recreate MultiUsers from scratch. Set False
+            to append another user into an existing DB (multi-user tests).
+        write_storage
+            When False, only update the multi-user DB (missing-blob tests).
+        db_row
+            Override the JSON stored in MultiUsers.TValue (missing username
+            / email / invalid-json tests). Defaults to username+email.
+        """
+        con = self._ensure_db(clear=clear_db)
+        try:
+            if db_row is None:
+                db_row = {"username": self.username, "email": self.email}
             con.execute(
                 "INSERT INTO MultiUsers VALUES (?, ?)",
-                (
-                    f"User:{self.user_id}",
-                    json.dumps({"username": self.username, "email": self.email}),
-                ),
+                (f"User:{self.user_id}", json.dumps(db_row)),
             )
             con.commit()
         finally:
             con.close()
 
-        ciphertext, iv = self._encrypt_userstore()
-        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
-        self.storage_path.write_text(
-            json.dumps(
-                {
-                    "iv": base64.b64encode(iv).decode("ascii"),
-                    # Evernote writes each raw byte as one ISO-8859-1 char.
-                    "encrypted": ciphertext.decode("latin-1"),
-                }
-            ),
-            encoding="utf-8",
-        )
+        if write_storage:
+            ciphertext, iv = self._encrypt_userstore()
+            self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+            self.storage_path.write_text(
+                json.dumps(
+                    {
+                        "iv": base64.b64encode(iv).decode("ascii"),
+                        # Evernote writes each raw byte as one ISO-8859-1 char.
+                        "encrypted": ciphertext.decode("latin-1"),
+                    }
+                ),
+                encoding="utf-8",
+            )
         return self.config_dir
+
+    def write_empty_db(self) -> Path:
+        """Create an empty MultiUsers table (no logged-in users)."""
+        con = self._ensure_db(clear=True)
+        con.commit()
+        con.close()
+        return self.config_dir
+
+    def write_raw_db_row(self, tkey: str, tvalue: str, *, clear: bool = False) -> None:
+        """Insert a raw MultiUsers row (invalid JSON / odd keys)."""
+        con = self._ensure_db(clear=clear)
+        try:
+            con.execute("INSERT INTO MultiUsers VALUES (?, ?)", (tkey, tvalue))
+            con.commit()
+        finally:
+            con.close()
 
     def patch_keyring(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Point ``keyring.get_password`` at this fake's AES key."""
@@ -163,6 +205,42 @@ def fake_desktop_session(tmp_path: Path) -> FakeDesktopSession:
     fake = FakeDesktopSession(tmp_path)
     fake.write()
     return fake
+
+
+# ---- _default_config_dir ----------------------------------------------------
+
+
+def test_default_config_dir_windows(monkeypatch):
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setenv("APPDATA", r"C:\Users\scott\AppData\Roaming")
+    assert _default_config_dir() == Path(r"C:\Users\scott\AppData\Roaming\Evernote")
+
+
+def test_default_config_dir_windows_no_appdata(monkeypatch):
+    """Without APPDATA, Windows falls through to ~/Evernote."""
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.delenv("APPDATA", raising=False)
+    monkeypatch.setattr(
+        "pathlib.Path.home", lambda: Path(r"C:\Users\scott"), raising=False
+    )
+    assert _default_config_dir() == Path(r"C:\Users\scott\Evernote")
+
+
+def test_default_config_dir_darwin(monkeypatch):
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.delenv("APPDATA", raising=False)
+    monkeypatch.setattr(
+        "pathlib.Path.home", lambda: Path("/Users/scott"), raising=False
+    )
+    assert _default_config_dir() == Path(
+        "/Users/scott/Library/Application Support/Evernote"
+    )
+
+
+def test_default_config_dir_unsupported_platform_raises(monkeypatch):
+    monkeypatch.setattr("sys.platform", "linux")
+    with pytest.raises(ProgramTerminatedError, match="only supported on Windows"):
+        _default_config_dir()
 
 
 # ---- list_desktop_users -----------------------------------------------------
@@ -183,6 +261,61 @@ def test_list_users_returns_logged_in_user(fake_desktop_session):
     # Secure-storage path is populated but token not yet decrypted
     assert u.s_token == ""
     assert u.storage_path == fake_desktop_session.storage_path
+
+
+def test_list_users_skips_invalid_json_rows(fake_desktop_session):
+    """Corrupt MultiUsers rows are skipped; valid users still returned."""
+    fake_desktop_session.write_raw_db_row("User:bad", "not-json{", clear=False)
+    users = list_desktop_users(fake_desktop_session.config_dir)
+    assert len(users) == 1
+    assert users[0].user_id == fake_desktop_session.user_id
+
+
+def test_list_users_missing_username_email_defaults(tmp_path):
+    """Missing username/email fields fall back to '?'."""
+    fake = FakeDesktopSession(tmp_path)
+    fake.write(db_row={})
+    users = list_desktop_users(fake.config_dir)
+    assert len(users) == 1
+    assert users[0].username == "?"
+    assert users[0].email == "?"
+
+
+def test_list_users_multiple(tmp_path):
+    u1 = FakeDesktopSession(tmp_path)
+    u1.user_id = "111"
+    u1.username = "alice"
+    u1.email = "alice@example.com"
+    u1.write()
+
+    u2 = FakeDesktopSession(tmp_path)
+    u2.user_id = "222"
+    u2.username = "bob"
+    u2.email = "bob@example.com"
+    u2.write(clear_db=False)
+
+    users = list_desktop_users(u1.config_dir)
+    assert [u.user_id for u in users] == ["111", "222"]
+    assert users[0].username == "alice"
+    assert users[1].username == "bob"
+
+
+def test_list_users_empty_db(tmp_path):
+    fake = FakeDesktopSession(tmp_path)
+    fake.write_empty_db()
+    assert list_desktop_users(fake.config_dir) == []
+
+
+def test_list_users_uses_default_config_dir(tmp_path, monkeypatch):
+    fake = FakeDesktopSession(tmp_path)
+    fake.write()
+    monkeypatch.setattr(
+        "evernote_backup.desktop_session._default_config_dir",
+        lambda: fake.config_dir,
+    )
+    users = list_desktop_users()
+    assert len(users) == 1
+    assert users[0].user_id == fake.user_id
 
 
 # ---- _decrypt_secure_blob ---------------------------------------------------
@@ -225,13 +358,28 @@ def test_keyring_service_and_account_darwin(monkeypatch):
     assert service == "Evernote"
 
 
-def test_get_os_key_roundtrip(fake_desktop_session, monkeypatch):
-    fake_desktop_session.patch_keyring(monkeypatch)
+def test_get_os_key_roundtrip_windows(fake_desktop_session, monkeypatch):
+    monkeypatch.setattr("sys.platform", "win32")
+    secret = fake_desktop_session.keyring_secret_for_platform("win32")
+    monkeypatch.setattr("keyring.get_password", lambda service, account: secret)
+    assert _get_os_key(fake_desktop_session.user_id) == fake_desktop_session.aes_key
+
+
+def test_get_os_key_roundtrip_darwin(fake_desktop_session, monkeypatch):
+    monkeypatch.setattr("sys.platform", "darwin")
+    secret = fake_desktop_session.keyring_secret_for_platform("darwin")
+    monkeypatch.setattr("keyring.get_password", lambda service, account: secret)
     assert _get_os_key(fake_desktop_session.user_id) == fake_desktop_session.aes_key
 
 
 def test_get_os_key_missing_raises(monkeypatch):
     monkeypatch.setattr("keyring.get_password", lambda service, account: None)
+    with pytest.raises(ProgramTerminatedError, match="No Evernote encryption key"):
+        _get_os_key("151636")
+
+
+def test_get_os_key_empty_secret_raises(monkeypatch):
+    monkeypatch.setattr("keyring.get_password", lambda service, account: "")
     with pytest.raises(ProgramTerminatedError, match="No Evernote encryption key"):
         _get_os_key("151636")
 
@@ -247,7 +395,29 @@ def test_get_os_key_locked_raises(monkeypatch):
         _get_os_key("151636")
 
 
-# ---- extract_token (with mocked OS key) -------------------------------------
+def test_get_os_key_keyring_error_raises(monkeypatch):
+    from keyring.errors import KeyringError
+
+    def _raise(*_a, **_k):
+        raise KeyringError("backend boom")
+
+    monkeypatch.setattr("keyring.get_password", _raise)
+    with pytest.raises(ProgramTerminatedError, match="Could not read credential"):
+        _get_os_key("151636")
+
+
+def test_get_os_key_unexpected_prefix_raises(monkeypatch):
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr(
+        "keyring.get_password",
+        lambda service, account: "wrong-prefix"
+        + base64.b64encode(b"\x11" * 32).decode(),
+    )
+    with pytest.raises(ProgramTerminatedError, match="unexpected prefix"):
+        _get_os_key("151636")
+
+
+# ---- extract_token ----------------------------------------------------------
 
 
 def test_extract_token(fake_desktop_session, monkeypatch):
@@ -267,6 +437,51 @@ def test_extract_token(fake_desktop_session, monkeypatch):
     assert session.email == fake_desktop_session.email
 
 
+def test_extract_token_without_user_id_single_user(fake_desktop_session, monkeypatch):
+    """With one user, user_id is optional and that user is chosen."""
+    fake_desktop_session.patch_keyring(monkeypatch)
+    session = extract_token(config_dir=fake_desktop_session.config_dir)
+    assert session.user_id == fake_desktop_session.user_id
+    assert session.s_token == fake_desktop_session.s_token
+
+
+def test_extract_token_multiple_users_picks_first(tmp_path, monkeypatch):
+    """With multiple users and no user_id, the first DB row is used."""
+    u1 = FakeDesktopSession(tmp_path)
+    u1.user_id = "111"
+    u1.s_token = "S=s1:U=111:token1"
+    u1.write()
+
+    u2 = FakeDesktopSession(tmp_path)
+    u2.user_id = "222"
+    u2.s_token = "S=s1:U=222:token2"
+    u2.aes_key = u1.aes_key
+    u2.write(clear_db=False)
+
+    u1.patch_keyring(monkeypatch)
+    session = extract_token(config_dir=u1.config_dir)
+    assert session.user_id == "111"
+    assert session.s_token == "S=s1:U=111:token1"
+
+
+def test_extract_token_multiple_users_picks_requested(tmp_path, monkeypatch):
+    u1 = FakeDesktopSession(tmp_path)
+    u1.user_id = "111"
+    u1.s_token = "S=s1:U=111:token1"
+    u1.write()
+
+    u2 = FakeDesktopSession(tmp_path)
+    u2.user_id = "222"
+    u2.s_token = "S=s1:U=222:token2"
+    u2.aes_key = u1.aes_key
+    u2.write(clear_db=False)
+
+    u1.patch_keyring(monkeypatch)
+    session = extract_token(user_id="222", config_dir=u1.config_dir)
+    assert session.user_id == "222"
+    assert session.s_token == "S=s1:U=222:token2"
+
+
 def test_extract_token_custom_jwt(fake_desktop_session, monkeypatch):
     """Custom JWT / refresh / client_id flow through the encrypted blob."""
     fake_desktop_session.jwt_access = "eyJ.custom.access"
@@ -282,6 +497,41 @@ def test_extract_token_custom_jwt(fake_desktop_session, monkeypatch):
     assert session.jwt_access == "eyJ.custom.access"
     assert session.jwt_refresh == "eyJ.custom.refresh"
     assert session.client_id == "custom-client-id"
+
+
+def test_extract_token_nullish_optional_fields(fake_desktop_session, monkeypatch):
+    """Empty/null optional JWT fields normalize to None; missing sh/h to ''."""
+    fake_desktop_session.jwt_access = None
+    fake_desktop_session.jwt_refresh = None
+    fake_desktop_session.client_id = None
+    fake_desktop_session.shard = None
+    fake_desktop_session.host = None
+    fake_desktop_session.write()
+    fake_desktop_session.patch_keyring(monkeypatch)
+
+    session = extract_token(
+        user_id=fake_desktop_session.user_id,
+        config_dir=fake_desktop_session.config_dir,
+    )
+    assert session.s_token == fake_desktop_session.s_token
+    assert session.shard == ""
+    assert session.host == ""
+    assert session.jwt_access is None
+    assert session.jwt_refresh is None
+    assert session.client_id is None
+
+
+def test_extract_token_empty_token_string_raises(fake_desktop_session, monkeypatch):
+    """Explicit empty 't' is treated as missing."""
+    fake_desktop_session.s_token = ""
+    fake_desktop_session.write()
+    fake_desktop_session.patch_keyring(monkeypatch)
+
+    with pytest.raises(ProgramTerminatedError, match="no 't' \\(token\\) field"):
+        extract_token(
+            user_id=fake_desktop_session.user_id,
+            config_dir=fake_desktop_session.config_dir,
+        )
 
 
 def test_extract_token_no_token_field_raises(fake_desktop_session, monkeypatch):
@@ -302,6 +552,20 @@ def test_extract_token_missing_user_raises(fake_desktop_session):
         extract_token(user_id="999999", config_dir=fake_desktop_session.config_dir)
 
 
+def test_extract_token_no_users_raises(tmp_path):
+    fake = FakeDesktopSession(tmp_path)
+    fake.write_empty_db()
+    with pytest.raises(ProgramTerminatedError, match="No logged-in Evernote desktop"):
+        extract_token(config_dir=fake.config_dir)
+
+
+def test_extract_token_missing_secure_storage_raises(tmp_path):
+    fake = FakeDesktopSession(tmp_path)
+    fake.write(write_storage=False)
+    with pytest.raises(ProgramTerminatedError, match="Secure-storage file"):
+        extract_token(user_id=fake.user_id, config_dir=fake.config_dir)
+
+
 def test_extract_token_key_missing_raises(fake_desktop_session, monkeypatch):
     monkeypatch.setattr("keyring.get_password", lambda service, account: None)
 
@@ -312,21 +576,13 @@ def test_extract_token_key_missing_raises(fake_desktop_session, monkeypatch):
         )
 
 
-# ---- _default_config_dir per platform --------------------------------------
-
-
-def test_default_config_dir_windows(monkeypatch):
-    monkeypatch.setattr("sys.platform", "win32")
-    monkeypatch.setenv("APPDATA", r"C:\Users\scott\AppData\Roaming")
-    assert _default_config_dir() == Path(r"C:\Users\scott\AppData\Roaming\Evernote")
-
-
-def test_default_config_dir_darwin(monkeypatch):
-    monkeypatch.setattr("sys.platform", "darwin")
-    monkeypatch.delenv("APPDATA", raising=False)
+def test_extract_token_uses_default_config_dir(tmp_path, monkeypatch):
+    fake = FakeDesktopSession(tmp_path)
+    fake.write()
+    fake.patch_keyring(monkeypatch)
     monkeypatch.setattr(
-        "pathlib.Path.home", lambda: Path("/Users/scott"), raising=False
+        "evernote_backup.desktop_session._default_config_dir",
+        lambda: fake.config_dir,
     )
-    assert _default_config_dir() == Path(
-        "/Users/scott/Library/Application Support/Evernote"
-    )
+    session = extract_token(user_id=fake.user_id)
+    assert session.s_token == fake.s_token

--- a/tests/test_op_init_db.py
+++ b/tests/test_op_init_db.py
@@ -5,6 +5,8 @@ import pytest
 from evernote_backup.cli_app_util import ProgramTerminatedError
 from evernote_backup.config import CURRENT_DB_VERSION
 from evernote_backup.note_storage import SqliteStorage
+from evernote_backup.desktop_session import DesktopSession
+from evernote_backup.token_util import OAuth2TokenBundle
 
 
 @pytest.mark.usefixtures("mock_evernote_client")
@@ -85,3 +87,34 @@ def test_init_db_touch_token(cli_invoker, mocker):
 
     assert result.exit_code == 1
     assert "test error" in result.output
+
+
+@pytest.mark.usefixtures("mock_evernote_client")
+def test_init_db_oauth_import(
+    tmp_path, cli_invoker, mock_oauth_client, mocker, fake_token_jwt
+):
+    test_db_path = tmp_path / "test.db"
+    refresh_token = OAuth2TokenBundle.from_json(fake_token_jwt).refresh_token
+
+    mocker.patch(
+        "evernote_backup.cli_app_auth_oauth.extract_token",
+        return_value=DesktopSession(
+            user_id="151636",
+            username="testuser",
+            email="test@example.com",
+            s_token="S=s1:U=1:E=1:C=1:P=1:A=a:V=2:H=h",
+            shard="s1",
+            host="www.evernote.com",
+            jwt_refresh=refresh_token,
+        ),
+    )
+
+    result = cli_invoker(
+        "init-db", "--database", test_db_path, "--oauth-method", "import"
+    )
+
+    storage = SqliteStorage(test_db_path)
+
+    assert result.exit_code == 0
+    assert "Imported OAuth refresh token" in result.output
+    assert storage.config.get_config_value("auth_token") == fake_token_jwt

--- a/tests/test_op_reauth.py
+++ b/tests/test_op_reauth.py
@@ -1,6 +1,7 @@
 import pytest
 
 from evernote_backup.token_util import OAuth2TokenBundle
+from evernote_backup.desktop_session import DesktopSession
 
 
 @pytest.fixture
@@ -339,7 +340,7 @@ def test_oauth_login(
     mocker.patch("evernote_backup.cli_app_util.click.echo")
     mock_launch = mocker.patch("evernote_backup.cli_app_util.click.launch")
 
-    result = cli_invoker("reauth", "-d", "fake_db", "--oauth-mcp")
+    result = cli_invoker("reauth", "-d", "fake_db", "--oauth-method", "mcp")
 
     assert result.exit_code == 0
     mock_launch.assert_called_once()
@@ -350,6 +351,108 @@ def test_oauth_login(
         fake_storage.config.get_config_value("auth_token")
         == mock_oauth_client.token_bundle.to_json()
     )
+
+
+@pytest.mark.usefixtures("mock_evernote_client")
+@pytest.mark.usefixtures("fake_init_db")
+def test_oauth_import(
+    cli_invoker, fake_storage, mock_oauth_client, mocker, fake_token_jwt
+):
+    refresh_token = OAuth2TokenBundle.from_json(fake_token_jwt).refresh_token
+
+    mocker.patch(
+        "evernote_backup.cli_app_auth_oauth.extract_token",
+        return_value=DesktopSession(
+            user_id="151636",
+            username="testuser",
+            email="test@example.com",
+            s_token="S=s1:U=1:E=1:C=1:P=1:A=a:V=2:H=h",
+            shard="s1",
+            host="www.evernote.com",
+            jwt_refresh=refresh_token,
+        ),
+    )
+
+    result = cli_invoker("reauth", "-d", "fake_db", "--oauth-method", "import")
+
+    assert result.exit_code == 0
+    assert "Imported OAuth refresh token" in result.output
+    assert fake_storage.config.get_config_value("auth_token") == fake_token_jwt
+
+
+@pytest.mark.usefixtures("mock_evernote_client")
+@pytest.mark.usefixtures("fake_init_db")
+def test_oauth_en_user_and_config_dir(
+    cli_invoker, fake_storage, mock_oauth_client, mocker, fake_token_jwt, tmp_path
+):
+    config_dir = tmp_path / "Evernote"
+    config_dir.mkdir()
+
+    refresh_token = OAuth2TokenBundle.from_json(fake_token_jwt).refresh_token
+
+    extract_mock = mocker.patch(
+        "evernote_backup.cli_app_auth_oauth.extract_token",
+        return_value=DesktopSession(
+            user_id="999",
+            username="other",
+            email="other@example.com",
+            s_token="S=s1:U=1:E=1:C=1:P=1:A=a:V=2:H=h",
+            shard="s1",
+            host="www.evernote.com",
+            jwt_refresh=refresh_token,
+        ),
+    )
+
+    result = cli_invoker(
+        "reauth",
+        "-d",
+        "fake_db",
+        "--oauth-method",
+        "import",
+        "--oauth-en-user",
+        "999",
+        "--oauth-en-config-dir",
+        str(config_dir),
+    )
+
+    assert result.exit_code == 0
+    extract_mock.assert_called_once()
+    call_kwargs = extract_mock.call_args.kwargs
+    assert call_kwargs["user_id"] == "999"
+    assert call_kwargs["config_dir"] == config_dir.resolve()
+    assert fake_storage.config.get_config_value("auth_token") == fake_token_jwt
+
+
+@pytest.mark.usefixtures("fake_init_db")
+def test_oauth_import_linux_error(cli_invoker, mocker):
+    mocker.patch("evernote_backup.cli_app_auth_oauth.sys.platform", "linux")
+
+    result = cli_invoker("reauth", "-d", "fake_db", "--oauth-method", "import")
+
+    assert result.exit_code == 1
+    assert "only supported on Windows and macOS" in result.output
+    assert "evertoken" in result.output
+
+
+@pytest.mark.usefixtures("fake_init_db")
+def test_oauth_import_missing_refresh_token(cli_invoker, fake_storage, mocker):
+    mocker.patch(
+        "evernote_backup.cli_app_auth_oauth.extract_token",
+        return_value=DesktopSession(
+            user_id="151636",
+            username="testuser",
+            email="test@example.com",
+            s_token="S=s1:U=1:E=1:C=1:P=1:A=a:V=2:H=h",
+            shard="s1",
+            host="www.evernote.com",
+            jwt_refresh=None,
+        ),
+    )
+
+    result = cli_invoker("reauth", "-d", "fake_db", "--oauth-method", "import")
+
+    assert result.exit_code == 1
+    assert "no OAuth refresh token" in result.output
 
 
 @pytest.mark.usefixtures("mock_output_to_terminal")
@@ -481,7 +584,13 @@ def test_oauth_login_custom_port(
     test_port = 10666
 
     result = cli_invoker(
-        "reauth", "-d", "fake_db", "--oauth-mcp", "--oauth-port", test_port
+        "reauth",
+        "-d",
+        "fake_db",
+        "--oauth-method",
+        "mcp",
+        "--oauth-port",
+        test_port,
     )
 
     assert result.exit_code == 0
@@ -512,7 +621,7 @@ def test_oauth_login_declined_error(
     mocker.patch("evernote_backup.cli_app_util.click.echo")
     mock_launch = mocker.patch("evernote_backup.cli_app_util.click.launch")
 
-    result = cli_invoker("reauth", "-d", "fake_db", "--oauth-mcp")
+    result = cli_invoker("reauth", "-d", "fake_db", "--oauth-method", "mcp")
 
     assert result.exit_code == 1
     assert "declined" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
+name = "backports-tarfile"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
@@ -260,6 +269,8 @@ dependencies = [
     { name = "click" },
     { name = "click-option-group" },
     { name = "evernote-plus" },
+    { name = "keyring", marker = "sys_platform == 'darwin' or sys_platform == 'win32'" },
+    { name = "pycryptodome", marker = "sys_platform == 'darwin' or sys_platform == 'win32'" },
     { name = "pyjwt" },
     { name = "requests-oauthlib" },
     { name = "requests-sse" },
@@ -285,7 +296,9 @@ requires-dist = [
     { name = "click", specifier = "==8.1.8" },
     { name = "click-option-group", specifier = "==0.5.7" },
     { name = "evernote-plus", specifier = "==1.28.1.dev2" },
-    { name = "pyjwt", specifier = ">=2.8.0" },
+    { name = "keyring", marker = "sys_platform == 'darwin' or sys_platform == 'win32'", specifier = "==25.7.0" },
+    { name = "pycryptodome", marker = "sys_platform == 'darwin' or sys_platform == 'win32'", specifier = "==3.23.0" },
+    { name = "pyjwt", specifier = "==2.13.0" },
     { name = "requests-oauthlib", specifier = "==2.0.0" },
     { name = "requests-sse", specifier = "==0.5.1" },
     { name = "thrift", specifier = "==0.21.0" },
@@ -357,12 +370,76 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/1f/c23395957d41ccf27c4e535c3d334c4051e5395b3752057ba4cbaec35c56/jaraco_functools-4.6.0.tar.gz", hash = "sha256:880c577ec9720b3a052d5bc611fb9f2269b3d87902ef42440df443b88e443280", size = 20837, upload-time = "2026-07-14T01:28:02.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl", hash = "sha256:99e3dc0060c5cbe8fcd1cdb36258e2a65ca40f1566b2033b12abb1bb44dd3c30", size = 11677, upload-time = "2026-07-14T01:28:01.59Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -397,6 +474,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
 ]
 
 [[package]]
@@ -458,6 +544,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/3a/ddb78f32a0814e66b18a099377a106a2dcdce92d86a034d69d65df9b256e/pre_commit-4.6.1.tar.gz", hash = "sha256:03e809865c7d178b9979d06c761fcbfe6808fdaded8581a745bb110e52050421", size = 198646, upload-time = "2026-07-21T20:56:58.225Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/49/bc925106abcdac498074f2cbe6137e94e09f418dd2b7775df5b577dc0313/pre_commit-4.6.1-py2.py3-none-any.whl", hash = "sha256:0e3b2942510d1fb34eec167a3ec57331bf8442122f1153a9fb8b58f5c49b2717", size = 226186, upload-time = "2026-07-21T20:56:57.064Z" },
+]
+
+[[package]]
+name = "pycryptodome"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/a6/8452177684d5e906854776276ddd34eca30d1b1e15aa1ee9cefc289a33f5/pycryptodome-3.23.0.tar.gz", hash = "sha256:447700a657182d60338bab09fdb27518f8856aecd80ae4c6bdddb67ff5da44ef", size = 4921276, upload-time = "2025-05-17T17:21:45.242Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/5d/bdb09489b63cd34a976cc9e2a8d938114f7a53a74d3dd4f125ffa49dce82/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0011f7f00cdb74879142011f95133274741778abba114ceca229adbf8e62c3e4", size = 2495152, upload-time = "2025-05-17T17:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ce/7840250ed4cc0039c433cd41715536f926d6e86ce84e904068eb3244b6a6/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:90460fc9e088ce095f9ee8356722d4f10f86e5be06e2354230a9880b9c549aae", size = 1639348, upload-time = "2025-05-17T17:20:23.171Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/34/e6c8ca177cb29dcc4967fef73f5de445912f93bd0343c9c33c8e5bf8cde8/pycryptodome-3.23.0-cp313-cp313t-win32.whl", hash = "sha256:257bb3572c63ad8ba40b89f6fc9d63a2a628e9f9708d31ee26560925ebe0210a", size = 1768600, upload-time = "2025-05-17T17:20:40.688Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/1d/89756b8d7ff623ad0160f4539da571d1f594d21ee6d68be130a6eccb39a4/pycryptodome-3.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6501790c5b62a29fcb227bd6b62012181d886a767ce9ed03b303d1f22eb5c625", size = 1799740, upload-time = "2025-05-17T17:20:42.413Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/61/35a64f0feaea9fd07f0d91209e7be91726eb48c0f1bfc6720647194071e4/pycryptodome-3.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9a77627a330ab23ca43b48b130e202582e91cc69619947840ea4d2d1be21eb39", size = 1703685, upload-time = "2025-05-17T17:20:44.388Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6c/a1f71542c969912bb0e106f64f60a56cc1f0fabecf9396f45accbe63fa68/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:187058ab80b3281b1de11c2e6842a357a1f71b42cb1e15bce373f3d238135c27", size = 2495627, upload-time = "2025-05-17T17:20:47.139Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/4e/a066527e079fc5002390c8acdd3aca431e6ea0a50ffd7201551175b47323/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:cfb5cd445280c5b0a4e6187a7ce8de5a07b5f3f897f235caa11f1f435f182843", size = 1640362, upload-time = "2025-05-17T17:20:50.392Z" },
+    { url = "https://files.pythonhosted.org/packages/59/fe/aae679b64363eb78326c7fdc9d06ec3de18bac68be4b612fc1fe8902693c/pycryptodome-3.23.0-cp37-abi3-win32.whl", hash = "sha256:507dbead45474b62b2bbe318eb1c4c8ee641077532067fec9c1aa82c31f84886", size = 1768484, upload-time = "2025-05-17T17:21:08.535Z" },
+    { url = "https://files.pythonhosted.org/packages/54/2f/e97a1b8294db0daaa87012c24a7bb714147c7ade7656973fd6c736b484ff/pycryptodome-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:c75b52aacc6c0c260f204cbdd834f76edc9fb0d8e0da9fbf8352ef58202564e2", size = 1799636, upload-time = "2025-05-17T17:21:10.393Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3d/f9441a0d798bf2b1e645adc3265e55706aead1255ccdad3856dbdcffec14/pycryptodome-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:11eeeb6917903876f134b56ba11abe95c0b0fd5e3330def218083c7d98bbcb3c", size = 1703675, upload-time = "2025-05-17T17:21:13.146Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/12/e33935a0709c07de084d7d58d330ec3f4daf7910a18e77937affdb728452/pycryptodome-3.23.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ddb95b49df036ddd264a0ad246d1be5b672000f12d6961ea2c267083a5e19379", size = 1623886, upload-time = "2025-05-17T17:21:20.614Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/92/2eadd1341abd2989cce2e2740b4423608ee2014acb8110438244ee97d7ff/pycryptodome-3.23.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:45c69ad715ca1a94f778215a11e66b7ff989d792a4d63b68dc586a1da1392ff5", size = 1803005, upload-time = "2025-05-17T17:21:31.37Z" },
 ]
 
 [[package]]
@@ -536,6 +642,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/51/276f964496a5714ab9f320896195639086881c2b39c03b5ad13de84acbb8/python_discovery-1.5.0.tar.gz", hash = "sha256:3e014c6327154d3dda27939a9a0dc9c5c000439f1906d3f303b48f984bd2ecef", size = 72483, upload-time = "2026-07-21T13:14:14.641Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/7b/14882602ddee241d7984a742fcb423cb4a30fb0d6efc546ac3129fba475a/python_discovery-1.5.0-py3-none-any.whl", hash = "sha256:70c4fc61b4e7404e44f01d6fc44a715c4d685ca6cea83d295922f05891877c98", size = 34205, upload-time = "2026-07-21T13:14:13.398Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -792,4 +907,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/39/0d/40df5be1e684bbaecdb9d1e0e40d5d482465de6b00cbb92b84ee5d243c7f/xmltodict-0.13.0.tar.gz", hash = "sha256:341595a488e3e01a85a9d8911d8912fd922ede5fecc4dce437eb4b6c8d037e56", size = 33813, upload-time = "2022-05-08T07:00:04.916Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/db/fd0326e331726f07ff7f40675cd86aa804bfd2e5016c727fa761c934990e/xmltodict-0.13.0-py2.py3-none-any.whl", hash = "sha256:aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852", size = 9971, upload-time = "2022-05-08T07:00:02.898Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
## Problem

Evernote (now owned by Bending Spoons) retired the legacy
`https://www.evernote.com/oauth` endpoint and is no longer issuing new
API keys or developer tokens. As a result, plain `evernote-backup
init-db` fails with:

```
ERROR: Unknown exception
requests_oauthlib.oauth1_session.TokenRequestDenied:
Token request failed with code 400, response was '<html>…Evernote
Error…Oops, we encountered an error.</html>'
```

This affects every existing user (see e.g. issue #165 and the
Evernote forum post at
https://discussion.evernote.com/forums/topic/153913-...).

## What's in this PR

Two commits that make the tool usable again, without waiting on
Evernote/Bending Spoons:

### 1. Friendly error when the legacy OAuth endpoint is dead
- `evernote_backup/evernote_client_oauth.py`: catch
  `TokenRequestDenied`, detect the "Evernote Error / Oops, we
  encountered an error." HTML body that the retired endpoint now
  returns, and raise a `ProgramTerminatedError` that points the user
  at the two still-working workarounds.
- 2 regression tests in `tests/test_evernote_client_oauth.py`:
  - `test_get_auth_token_legacy_oauth_retired`: fires the new
    error path and asserts the workaround message is included.
  - `test_get_auth_token_real_oauth_error_is_not_masked`: a
    non-HTML 400 still surfaces the generic OAuth failure, so we
    don't mis-direct users when the real problem is something
    else.

### 2. `--from-desktop-session` flag
- New module `evernote_backup/desktop_session.py`: Python port of
  the algorithm in vzhd1701/evertoken that pulls the `S=...` token
  out of the user's local Evernote desktop profile.
  - Cross-platform: `win32cred` on Windows, `/usr/bin/security` on
    macOS, `secret-tool` (libsecret) on Linux.
  - AES-256-CBC decrypt of `secure-storage/authtoken_user_<id>`
    using a key fetched from the OS secret store
    (`Evernote/AuthToken:User:<id>`).
  - Returns a `DesktopSession` with `s_token`, `jwt_access`,
    `jwt_refresh`, `shard`, `host`, `user_id`, `username`, `email`.
- CLI: new `--from-desktop-session` (and `--desktop-user <id>` for
  multi-user systems) on `init-db` and `reauth`. Auto-detects
  `--backend` from the recovered session's host (e.g.
  `app.yinxiang.com` → `china`) but only when the user didn't pass
  `--backend` explicitly (via `click.Context.get_parameter_source`).
- 12 unit tests in `tests/test_desktop_session.py` and 4 CLI
  integration tests in `tests/test_op_init_db.py`. Full suite goes
  from 214 → 232 passing.
- README: new "Reusing a logged-in Evernote desktop client"
  section under Step 1, and a one-line note in the Tasks section
  pointing at `--from-desktop-session` as the primary way to feed
  a desktop token to `--include-tasks` sync.

## How users unblock themselves

Before this PR, the only answer to "init-db doesn't work" was
"switch to the legacy desktop app and use evertoken manually to
extract a token, then pass `--token`. After this PR:

```
$ evernote-backup init-db --from-desktop-session --database en_backup.db
Recovered auth token from Evernote desktop session for <user> <<email>> (user id <id>).
Authorizing auth token, evernote backend...
Successfully authenticated as <user>!
Initializing database en_backup.db...
Successfully initialized database for <user>!

$ evernote-backup sync
... syncs normally ...
```

End-to-end smoke test against the real Evernote API confirmed
init-db + sync + auth works using the recovered token.

## Why this is the right shape

- The bulkbackup key was the only Evernote-blessed path for
  third-party desktop backup; restoring it is outside our control.
- Reusing the desktop client's session is the same approach the
  upstream author already ships as a separate `evertoken` tool -
  this just folds it into the same `evernote-backup` binary so
  people don't have to install two tools.
- The friendly error message is the lowest-risk first patch
  possible: a few lines, no behaviour change for working setups,
  and immediately points new users at the new flag.
